### PR TITLE
ReindexFile command and minor bugfix.

### DIFF
--- a/plugin/rtags.vim
+++ b/plugin/rtags.vim
@@ -151,11 +151,11 @@ function! rtags#JumpTo()
         let [location; symbol_detail] = split(results[0], '\s\+')
         let [jump_file, lnum, col; rest] = split(location, ':')
 
+        " Add location to the jumplist
+        normal m'
         if jump_file != expand("%:p")
             exe "e ".jump_file
         endif
-        " Add location to the jumplist
-        normal m'
         call cursor(lnum, col)
         normal zz
     endif
@@ -190,12 +190,11 @@ function! rtags#JumpToParent()
         if parentSeparatorPassed == 1
             let [jump_file, lnum, col] = rtags#parseSourceLocation(line)
             if !empty(jump_file)
-                echo jump_file.":".lnum
+                " Add location to the jumplist
+                normal m'
                 if jump_file != expand("%:p")
                     exe "e ".jump_file
                 endif
-                " Add location to the jumplist
-                normal m'
                 call cursor(lnum, col)
                 normal zz
                 return


### PR DESCRIPTION
Hi, ReindexFile can be useful to trigger rdm reindex to the actual file. Though rdm should do this automatically, but for debugging purposes of rdm this can be really handy.

Also adding the location to the jump list is necessary, otherwise the when the file stays the same during the jump, the location is not added to list.

Gabor
