### PR TITLE
Respect set completefunc

### DIFF
--- a/plugin/rtags.vim
+++ b/plugin/rtags.vim
@@ -304,7 +304,9 @@ function! RtagsCompleteFunc(findstart, base)
 endfunction
 
 
-set completefunc=RtagsCompleteFunc
+if (!exists('&completefunc'))
+  set completefunc=RtagsCompleteFunc
+endif
 
 " Helpers to access script locals for unit testing {{{
 function! s:get_SID()


### PR DESCRIPTION
It would be great if vim-rtags wouldn't overwrite an existing, set `completefunc`.
