### PR TITLE
Displaye error message when current file is not indexed

### DIFF
--- a/plugin/rtags.vim
+++ b/plugin/rtags.vim
@@ -76,7 +76,7 @@ function! rtags#ExecuteRC(args, ...)
         endif
     endfor
     let output = system(cmd)
-    if output =~ 'Not indexed'
+    if output =~ '^Not indexed'
         echohl ErrorMsg | echomsg "[vim-rtags] Current file is not indexed!" | echohl None
         return []
     endif

--- a/plugin/rtags.vim
+++ b/plugin/rtags.vim
@@ -75,8 +75,12 @@ function! rtags#ExecuteRC(args, ...)
             let cmd .= " ".value
         endif
     endfor
-    let output = split(system(cmd), '\n\+')
-    return output
+    let output = system(cmd)
+    if output =~ 'Not indexed'
+        echohl ErrorMsg | echomsg "[vim-rtags] Current file is not indexed!" | echohl None
+        return []
+    endif
+    return split(output, '\n\+')
 endfunction
 
 function! rtags#CreateProject()
@@ -119,7 +123,9 @@ endfunction
 function! rtags#DisplayResults(results)
     let locations = rtags#ParseResults(a:results)
     call setloclist(winnr(), locations)
-    lopen
+    if len(locations) > 0
+        lopen
+    endif
 endfunction
 
 function! rtags#getRcCmd()


### PR DESCRIPTION
I think it would be nice to get an error message, instead of an stack trace, when rc command fails due to the current file not being indexed.