### PR TITLE
Add option to use QuickFix window instead of location list for results

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ default mappings can be disabled:
 
     let g:rtagsUseDefaultMappings = 0
 
+By default, search results are showed in a location list. Location lists
+are local to the current window. To use the vim QuickFix window, which is
+shared between all windows, set:
+
+    let g:rtagsUseLocationList = 0
+
 # Usage
 Code completion functionality uses ```completefunc``` (i.e. CTRL-X CTRL-U).
 

--- a/plugin/rtags.vim
+++ b/plugin/rtags.vim
@@ -6,6 +6,10 @@ endif
 let g:rcCmd = "rc"
 let g:excludeSysHeaders = 0
 
+if !exists("g:rtagsUseLocationList")
+    let g:rtagsUseLocationList = 1
+endif
+
 if !has("g:rtagsUseDefaultMappings")
     let g:rtagsUseDefaultMappings = 1
 endif
@@ -125,9 +129,16 @@ endfunction
 " Format of each line: <path>,<line>\s<text>
 function! rtags#DisplayResults(results)
     let locations = rtags#ParseResults(a:results)
-    call setloclist(winnr(), locations)
-    if len(locations) > 0
-        lopen
+    if g:rtagsUseLocationList == 1
+        call setloclist(winnr(), locations)
+        if len(locations) > 0
+            lopen
+        endif
+    else
+        call setqflist(locations)
+        if len(locations) > 0
+            copen
+        endif
     endif
 endfunction
 


### PR DESCRIPTION
Add option to use QuickFix window instead of location list for displaying results. QuickFix window shared between all windows, unlike location list, maybe useful for some workflows. This provides an option that the user can use to choose this behavior.