### PR TITLE
Add function to search for virtual function implementations

### DIFF
--- a/plugin/rtags.vim
+++ b/plugin/rtags.vim
@@ -27,6 +27,7 @@ if g:rtagsUseDefaultMappings == 1
     noremap <Leader>rr :call rtags#ReindexFile()<CR>
     noremap <Leader>rl :call rtags#ProjectList()<CR>
     noremap <Leader>rw :call rtags#RenameSymbolUnderCursor()<CR>
+    noremap <Leader>rv :call rtags#FindVirtuals()<CR>
     noremap 6 :call rtags#CompleteAtCursor()<CR>
 endif
 
@@ -281,6 +282,14 @@ endfunction
 function! rtags#FindRefs()
     let args = {}
     let args.e = ''
+    let args.r = rtags#getCurrentLocation()
+    let result = rtags#ExecuteRC(args)
+    call rtags#DisplayResults(result)
+endfunction
+
+function! rtags#FindVirtuals()
+    let args = {}
+    let args.k = ''
     let args.r = rtags#getCurrentLocation()
     let result = rtags#ExecuteRC(args)
     call rtags#DisplayResults(result)


### PR DESCRIPTION
Hello @lyuts , thanks for this nice plugin! I've added a simple function and '\<leader\>rv' mapping that uses rtags '-k' option to search for other implementations of the virtual function under cursor. I use it for understanding code bases with large number of virtuals, so I hope that other people will also find it usefull. What do you think about it?