### PR TITLE
Fix interplay of renaming and folding

### DIFF
--- a/plugin/rtags.vim
+++ b/plugin/rtags.vim
@@ -256,6 +256,7 @@ function! rtags#RenameSymbolUnderCursor()
         if !empty(newName)
             for loc in reverse(locations)
                 call rtags#jumpToLocation(loc.filepath, loc.lnum, loc.col)
+                normal zv
                 normal zz
                 redraw
                 let choice = yesToAll
@@ -269,7 +270,6 @@ function! rtags#RenameSymbolUnderCursor()
                     let yesToAll = 1
                 endif
                 if choice == 1
-                    normal zv
                     exec "normal ciw".newName."\<Esc>"
                     write!
                 elseif choice == 4

--- a/plugin/rtags.vim
+++ b/plugin/rtags.vim
@@ -269,6 +269,7 @@ function! rtags#RenameSymbolUnderCursor()
                     let yesToAll = 1
                 endif
                 if choice == 1
+                    normal zv
                     exec "normal ciw".newName."\<Esc>"
                     write!
                 elseif choice == 4


### PR DESCRIPTION
If the user has folding enabled we need to open them at least that much,
that we can work on a proper word at the rename location (otherwise e.g.
`ciw` would change the whole fold).