### PR TITLE
Always request rc to report absolute paths

### DIFF
--- a/plugin/rtags.vim
+++ b/plugin/rtags.vim
@@ -147,10 +147,12 @@ function! rtags#DisplayResults(results)
 endfunction
 
 function! rtags#getRcCmd()
+    let cmd = g:rcCmd
+    let cmd .= " --absolute-path "
     if g:excludeSysHeaders == 1
-        return g:rcCmd." -H "
+        return cmd." -H "
     endif
-    return g:rcCmd
+    return cmd
 endfunction
 
 function! rtags#getCurrentLocation()


### PR DESCRIPTION
With Andersbakken/rtags#429 the default behavior of `rc` was changed so
that now all reported paths are by default relative to the project root.
To accomodate this we should always explicitly request absolute paths
with `--absolute-path`. This flag has existed for quite a time so I
expect little breakage when interfacing older rtags versions.