### PR TITLE
Proper error message when rdm is not running

### DIFF
--- a/plugin/rtags.vim
+++ b/plugin/rtags.vim
@@ -86,6 +86,11 @@ function! rtags#ExecuteRC(args, ...)
         endif
     endfor
     let output = system(cmd)
+    if v:shell_error && len(output) > 0
+        let output = substitute(output, '\n', '', '')
+        echohl ErrorMsg | echomsg "[vim-rtags] Error: " . output | echohl None
+        return []
+    endif
     if output =~ '^Not indexed'
         echohl ErrorMsg | echomsg "[vim-rtags] Current file is not indexed!" | echohl None
         return []


### PR DESCRIPTION
Display an error message when rdm is not running, instead of displaying
an empty location list.