### PR TITLE
fix typo in rename under cursor function

### DIFF
--- a/plugin/rtags.vim
+++ b/plugin/rtags.vim
@@ -318,7 +318,7 @@ function! rtags#RenameSymbolUnderCursor()
             for loc in reverse(locations)
                 if !rtags#jumpToLocationInternal(loc.filepath, loc.lnum, loc.col)
                     return
-                fi
+                endif
                 normal zv
                 normal zz
                 redraw


### PR DESCRIPTION
I noticed that rename (`<leader>rw`) function doesn't work now. I found a bash-style typo in it (AFAIK vim doesn't support `if` termination with `fi`), fixed it with this commit, so rename works for me again.