### PR TITLE
Correct ExtractSuperClass and ExtractSubClass behavior

### DIFF
--- a/doc/rtags.txt
+++ b/doc/rtags.txt
@@ -160,13 +160,13 @@ g:rtagsLog
     <Leader>rv      Find other implementations of a function, such as virtual
                     functions.
 
-							    *rtags-leader-rC*
+                                                            *rtags-leader-rC*
                                                             *rtags-FindSuperClasses*
-    <Leader>rC      Find the super classes of the class under the cursor.
+    <Leader>rC      Find the superclasses of the class under the cursor.
 
-							    *rtags-leader-rc*
+                                                            *rtags-leader-rc*
                                                             *rtags-FindSubClasses*
-    <Leader>rc      Find the sub classes of the class under the cursor.
+    <Leader>rc      Find the subclasses of the class under the cursor.
 
                                                                 *rtags-commands*
 5. Commands

--- a/plugin/rtags.vim
+++ b/plugin/rtags.vim
@@ -150,6 +150,10 @@ function! rtags#ParseResults(results)
     return locations
 endfunction
 
+function! rtags#ExtractClassHierarthyLine(line)
+    return substitute(a:line, '\v.*\s+(\S+:[0-9]+:[0-9+]:\s)', '\1', '')
+endfunction
+
 "
 " Converts a class hierarchy of 'rc --class-hierarchy' like:
 "
@@ -179,7 +183,7 @@ function! rtags#ExtractSuperClasses(results)
             break
         endif
 
-        let extLine = substitute(line, '\s\+class\s\+[a-zA-Z0-9_]\+\s\+', '', '')
+        let extLine = rtags#ExtractClassHierarthyLine(line)
         call add(extracted, extLine)
     endfor
     return extracted
@@ -215,7 +219,7 @@ function! rtags#ExtractSubClasses(results)
            continue
         endif
 
-        let extLine = substitute(line, '\s\+class\s\+[a-zA-Z0-9_]\+\s\+', '', '')
+        let extLine = rtags#ExtractClassHierarthyLine(line)
         call add(extracted, extLine)
     endfor
     return extracted


### PR DESCRIPTION
The current implementation of extracting super- and subclasses doesn't work for `struct`s and templates. This pull request attempts to fix that.

Also correct spelling in the help: it's called superclass and subclass, not super class and sub class.