### PR TITLE
Save full path to stack.

### DIFF
--- a/plugin/rtags.vim
+++ b/plugin/rtags.vim
@@ -345,7 +345,7 @@ endfunction
 
 function! rtags#saveLocation()
   let [lnum, col] = getpos('.')[1:2]
-  call rtags#pushToStack([expand("%"), lnum, col])
+  call rtags#pushToStack([expand("%:p"), lnum, col])
 endfunction
 
 function! rtags#pushToStack(location)


### PR DESCRIPTION
Hi,

Returning to the previous location can fail if the previous file is
in a different directory to the current one, because only the file's
basename is stored in the location stack.

This patch fixes this by storing the fully qualified path in the stack.

E.g. after opening dirA/foo, then jumping to dirB/bar, trying to go back would make vim try and open dirB/foo, when it should be dirA/foo.

Cheers!