### PR TITLE
Fix spelling and regex in rtags#ExtractClassHierarchyLine

### DIFF
--- a/plugin/rtags.vim
+++ b/plugin/rtags.vim
@@ -157,8 +157,8 @@ function! rtags#ParseResults(results)
     return locations
 endfunction
 
-function! rtags#ExtractClassHierarthyLine(line)
-    return substitute(a:line, '\v.*\s+(\S+:[0-9]+:[0-9+]:\s)', '\1', '')
+function! rtags#ExtractClassHierarchyLine(line)
+    return substitute(a:line, '\v.*\s+(\S+:[0-9]+:[0-9]+:\s)', '\1', '')
 endfunction
 
 "
@@ -190,7 +190,7 @@ function! rtags#ExtractSuperClasses(results)
             break
         endif
 
-        let extLine = rtags#ExtractClassHierarthyLine(line)
+        let extLine = rtags#ExtractClassHierarchyLine(line)
         call add(extracted, extLine)
     endfor
     return extracted
@@ -226,7 +226,7 @@ function! rtags#ExtractSubClasses(results)
             continue
         endif
 
-        let extLine = rtags#ExtractClassHierarthyLine(line)
+        let extLine = rtags#ExtractClassHierarchyLine(line)
         call add(extracted, extLine)
     endfor
     return extracted


### PR DESCRIPTION
In FindSuperClasses/FindSubClasses, when vim parses the output of rtags, the invalid regex leads to all the super/sub classes being linked together in one mass until it gets to the end or it finds one that's column number has a single digit.