### PR TITLE
add unite replace support

### DIFF
--- a/autoload/unite/rtags.vim
+++ b/autoload/unite/rtags.vim
@@ -10,6 +10,10 @@ function! unite#rtags#get_filecol(result)
     return split(a:result, ':')[2]
 endfunction
 
+function! unite#rtags#get_filetext(result)
+    return substitute( split(a:result, ':')[3], '^\t', '', '')
+endfunction
+
 function! unite#rtags#get_word(result)
     let cwd = getcwd()
     let relpath = split(a:result, cwd.'/')[0]

--- a/autoload/unite/rtags.vim
+++ b/autoload/unite/rtags.vim
@@ -11,7 +11,7 @@ function! unite#rtags#get_filecol(result)
 endfunction
 
 function! unite#rtags#get_filetext(result)
-    return substitute( split(a:result, ':')[3], '^\t', '', '')
+    return substitute( a:result, '^[^:]\+:[^:]\+:[^:]\+:\t', '', '')
 endfunction
 
 function! unite#rtags#get_word(result)

--- a/autoload/unite/sources/rtags_references.vim
+++ b/autoload/unite/sources/rtags_references.vim
@@ -38,5 +38,6 @@ function! s:source_rtags_references.gather_candidates(args, context)
                 \ 'action__path': unite#rtags#get_filepath(v:val),
                 \ 'action__line': unite#rtags#get_fileline(v:val),
                 \ 'action__col': unite#rtags#get_filecol(v:val),
+                \ 'action__text': unite#rtags#get_filetext(v:val)
                 \ }")
 endfunction

--- a/autoload/unite/sources/rtags_symbol.vim
+++ b/autoload/unite/sources/rtags_symbol.vim
@@ -56,5 +56,6 @@ function! s:source_rtags_symbol.gather_candidates(args, context)
                 \ 'action__path': unite#rtags#get_filepath(v:val),
                 \ 'action__line': unite#rtags#get_fileline(v:val),
                 \ 'action__col': unite#rtags#get_filecol(v:val),
+                \ 'action__text': unite#rtags#get_filetext(v:val)
                 \ }")
 endfunction


### PR DESCRIPTION
Added the action__text option to use the replace command in unite.vim.