### PR TITLE
Added setting of syntax highlight

### DIFF
--- a/autoload/unite/sources/rtags_references.vim
+++ b/autoload/unite/sources/rtags_references.vim
@@ -22,6 +22,8 @@ function! s:source_rtags_references.hooks.on_syntax(args, context)
     execute 'syntax match uniteSource__RtagsReferences_Symbol /'
                 \ . a:context.source__cword
                 \ . '/ contained containedin=uniteSource__RtagsReferences'
+    syntax match uniteSource__RtagsReferences_Separator /:/ contained
+          \ containedin=uniteSource__RtagsReferences_File,uniteSource__RtagsReferences_LineNR
     highlight default link uniteSource__RtagsReferences_File Comment
     highlight default link uniteSource__RtagsReferences_LineNr LineNR
     highlight default link uniteSource__RtagsReferences_Symbol Function


### PR DESCRIPTION
When there was ':' in the code, the syntax highlight was not working properly.
Example 
```
value = is_true? 1 : 2;
```

A comparator was added to the syntax setting.