### PR TITLE
Adds a call tree for viewing references to symbols

### DIFF
--- a/doc/rtags.txt
+++ b/doc/rtags.txt
@@ -144,6 +144,12 @@ g:rtagsLog
                                                                *rtags-FindRefs*
     <Leader>rf      Find references of the symbol under the cursor.
 
+                                                        *rtags-leader-rF*
+                                                        *rtags-FindRefsCallTree*
+    <Leader>rF      Find references of the symbol under the cursor in a tree
+                    view. In this view, press 'o' to expand any reference to
+                    find callers to the function containing that reference.
+
                                                           *rtags-leader-rn*
                                                           *rtags-FindRefsByName*
     <Leader>rn      Find symbol(s) references that match the provided pattern.

--- a/plugin/rtags.vim
+++ b/plugin/rtags.vim
@@ -288,6 +288,7 @@ function! rtags#ViewReferences(results)
     setlocal buftype=nowrite
     setlocal bufhidden=delete
     setlocal nowrap
+    setlocal tw=0
 
     iabc <buffer>
 
@@ -336,22 +337,17 @@ function! s:OpenReference() " <<<
     " Detect openable region
     let nr = matchlist(l, '#\([0-9]\+\)$')[1]
     if !empty(nr)
-        let f = b:rtagsLocations[nr].filename
+        let jump_file = b:rtagsLocations[nr].filename
         let lnum = b:rtagsLocations[nr].lnum
         let col = b:rtagsLocations[nr].col
-        let oldwin = winnr()
-        wincmd p
-        if oldwin == winnr() || &modified
-            wincmd p
-            exec ("new " . f)
-        else
-            exec ("edit " . f)
+        wincmd j
+        " Add location to the jumplist
+        normal m'
+        if rtags#jumpToLocation(jump_file, lnum, col)
+            normal zz
         endif
-        silent execute "normal! ".lnum."G".col."|"
-        wincmd p
     endif
 endfunction " >>>
-
 
 "
 " Adds the list of references below the targeted item in the reference

--- a/plugin/rtags.vim
+++ b/plugin/rtags.vim
@@ -335,7 +335,7 @@ function! s:OpenReference() " <<<
 
     " Detect openable region
     let nr = matchlist(l, '#\([0-9]\+\)$')[1]
-    if nr
+    if !empty(nr)
         let f = b:rtagsLocations[nr].filename
         let lnum = b:rtagsLocations[nr].lnum
         let col = b:rtagsLocations[nr].col


### PR DESCRIPTION
The <leader>rF command is bound to a reference viewer which is capable
of showing the call tree leading to a particular reference. Tree nodes
can be expanded by pressing o and can be viewed by pressing return.