### PR TITLE
Add vimrtags.py and implement rtags#Diagnostics in python.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ It is possible to set its maximum size (number of entries), default is 100:
 | &lt;Leader&gt;rw | -e -r --rename                   | Rename symbol under cursor                 |
 | &lt;Leader&gt;rv | -k -r                            | Find virtuals                              |
 | &lt;Leader&gt;rb | N/A                              | Jump to previous location                  |
+| &lt;Leader&gt;rd | --diagnose                       | Show diagnostics                           |
 
 ## Unite sources
 

--- a/plugin/vimrtags.py
+++ b/plugin/vimrtags.py
@@ -1,0 +1,38 @@
+import vim
+import json
+import subprocess
+import io
+import logging
+
+def initialize():
+    logfile = vim.eval('g:rtagsPythonLog')
+    if logfile != None:
+        logging.basicConfig(filename = logfile, level=logging.DEBUG)
+
+def display_diagnostics_results():
+    results = vim.eval('s:results')
+    if len(results) == 0:
+        return
+
+    data = json.loads(results[0])
+
+    filename, errors = list(data['checkStyle'].items())[0]
+    quickfix_errors = []
+
+    for i, e in enumerate(errors):
+        if e['type'] == 'skipped':
+            continue
+
+        # strip error prefix
+        s = ' Issue: '
+        index = e['message'].find(s)
+        if index != -1:
+          e['message'] = e['message'][index + len(s):]
+          error_type = 'E' if e['type'] == 'error' else 'W'
+          quickfix_errors.append({'lnum': e['line'], 'col': e['column'],
+              'nr': i, 'text': e['message'], 'filename': filename,
+              'type': error_type})
+          cmd = 'sign place %d line=%s name=%s file=%s' % (i + 1, e['line'], e['type'], filename)
+          vim.command(cmd)
+
+    vim.eval('rtags#DisplayLocations(%s)' % json.dumps(quickfix_errors))


### PR DESCRIPTION
The submit request reworks rtags#Diagnostics() functionality to proper Python part in a separate engine.
Reworked version uses just JSON which makes the implementation smoother.
I'm also working on better completion support where I would like to implement majority of functionality also in Python part of the plugin. That's my motivation to do the separation. 