### PR TITLE
Add JumpToMethod to vim-rtags

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ It is possible to set its maximum size (number of entries), default is 100:
 | &lt;Leader&gt;rw | -e -r --rename                   | Rename symbol under cursor                 |
 | &lt;Leader&gt;rv | -k -r                            | Find virtuals                              |
 | &lt;Leader&gt;rb | N/A                              | Jump to previous location                  |
+| &lt;Leader&gt;ro | --kind-filter -i -F              | Find method in current file                | 
 
 ## Unite sources
 

--- a/doc/rtags.txt
+++ b/doc/rtags.txt
@@ -186,6 +186,10 @@ g:rtagsLog
                                                             *rtags-FindSubClasses*
     <Leader>rc      Find the subclasses of the class under the cursor.
 
+                                                            *rtags-leader-ro*
+                                                            *rtags-JumpToMethod*
+    <Leader>ro      Find and jump to method in current file.
+
                                                                 *rtags-commands*
 5. Commands
 

--- a/plugin/rtags.vim
+++ b/plugin/rtags.vim
@@ -83,6 +83,7 @@ if g:rtagsUseDefaultMappings == 1
     noremap <Leader>rb :call rtags#JumpBack()<CR>
     noremap <Leader>rC :call rtags#FindSuperClasses()<CR>
     noremap <Leader>rc :call rtags#FindSubClasses()<CR>
+    noremap <Leader>ro :call rtags#JumpToMethod(input("Pattern? ", "", "customlist,rtags#CompleteSymbols"))<CR>
     noremap <Leader>rd :call rtags#Diagnostics()<CR>
 endif
 
@@ -414,6 +415,16 @@ function! rtags#JumpTo(open_opt, ...)
     call extend(args, { '-f' : rtags#getCurrentLocation() })
     let results = rtags#ExecuteThen(args, [[function('rtags#JumpToHandler'), { 'open_opt' : a:open_opt }]])
 
+endfunction
+
+function! rtags#JumpToMethod(pattern)
+    let current_file = expand("%")
+    let args = {
+                \ '-a' : '',
+                \ '-F': a:pattern,
+                \ '--kind-filter': 'CXXMethod',
+                \ '-i': current_file }
+    let results = rtags#ExecuteThen(args, [[function('rtags#JumpToHandler'), { 'open_opt' : g:SAME_WINDOW }]])
 endfunction
 
 function! rtags#parseSourceLocation(string)


### PR DESCRIPTION
I wanted functionality in vim-rtags to jump to a particular method that exists in the current file.  Since rtags allows you to search for a symbol, filtered by method type, in a particular file, I was able to combine these flags for this purpose.   This is an initial take on this and has worked pretty well for me so far, so looking to see if this would be of interest to the upstream repo.