### PR TITLE
Send absolute file paths to 'rc' command

### DIFF
--- a/plugin/rtags.vim
+++ b/plugin/rtags.vim
@@ -331,7 +331,7 @@ endfunction
 
 function! rtags#getCurrentLocation()
     let [lnum, col] = getpos('.')[1:2]
-    return printf("%s:%s:%s", expand("%"), lnum, col)
+    return printf("%s:%s:%s", expand("%:p"), lnum, col)
 endfunction
 
 function! rtags#SymbolInfoHandler(output)


### PR DESCRIPTION
Currently all commands are using the '--absolute-path' command line
option to the 'rc' command which means that a file location will be
taken as absolute. However the rtags#getCurrentLocation() function we
are using plain 'expand' which gives back the pwd relative path of the
current buffer.

Add the ':p' modifier to the expand command in the
rtags#getCurrentLocation() function so that it will pass absolute paths
to the 'rc' command.