### PR TITLE
Remove using uninitialized variable

### DIFF
--- a/plugin/rtags.vim
+++ b/plugin/rtags.vim
@@ -13,7 +13,7 @@ if has('python')
 elseif has('python3')
     let g:rtagsPy = 'python3'
 else
-    echohl ErrorMsg | echomsg "[vim-rtags] Vim is missing python support" . output | echohl None
+    echohl ErrorMsg | echomsg "[vim-rtags] Vim is missing python support" | echohl None
     finish
 end
 


### PR DESCRIPTION
 when python and python3 are not enabled. Without this, an error is shown during startup when used with vim from debian

Signed-off-by: Raju K <rajukv@gmail.com>