### PR TITLE
Neovim and python35 fixes

### DIFF
--- a/plugin/rtags.vim
+++ b/plugin/rtags.vim
@@ -670,7 +670,7 @@ function! rtags#ExecuteRCAsync(args, handlers)
     let s:job_cid = s:job_cid + 1
     " should have out+err redirection portable for various shells.
     if has('nvim')
-        let cmd = cmd . '>& ' . rtags#TempFile(s:job_cid)
+        let cmd = cmd . ' >' . rtags#TempFile(s:job_cid) . ' 2>&1'
         let job = jobstart(cmd, s:callbacks)
         let s:jobs[job] = s:job_cid
         let s:result_handlers[job] = a:handlers

--- a/plugin/vimrtags.py
+++ b/plugin/vimrtags.py
@@ -32,10 +32,9 @@ def run_rc_command(arguments, content = None):
     if sys.version_info.major == 3 and sys.version_info.minor >= 5:
         r = subprocess.run(
             cmdline.split(),
-            input = content,
+            input = content.encode(encoding),
             stdout = subprocess.PIPE,
             stderr = subprocess.PIPE,
-            shell = True
         )
         out, err = r.stdout, r.stderr
         if not out is None:


### PR DESCRIPTION
There are a couple of fixes to be able to work with vim-rtags from neovim with default shell set to /bin/sh and python 3.5.