### PR TITLE
Logfile name in the temp directory starts with the user name for uniqueness

### DIFF
--- a/plugin/vimrtags.py
+++ b/plugin/vimrtags.py
@@ -5,10 +5,11 @@ import io
 import os
 import sys
 import tempfile
+import getpass
 
 import logging
 tempdir = tempfile.gettempdir()
-logging.basicConfig(filename='%s/vim-rtags-python.log' % tempdir,level=logging.DEBUG)
+logging.basicConfig(filename=os.path.join(tempdir, '{user_name}-vim-rtags-python.log'.format(user_name=getpass.getuser())),level=logging.DEBUG)
 
 def get_identifier_beginning():
     line = vim.eval('s:line')


### PR DESCRIPTION
In a shared development environment the fixed file name present a problem. The file name should contain something unique, like the user name to avoid the collision of the vim-s run by different users on the same host.