### PR TITLE
Diagnostics improvements + other tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ default mappings can be disabled:
 
     let g:rtagsUseDefaultMappings = 0
 
+Diagnostics will be retrieved from rtags automatically and displayed as signs in the gutter column.
+To disable this behaviour, set:
+
+    let g:rtagsAutoDiagnostics = 0
+
 By default, search results are showed in a location list. Location lists
 are local to the current window. To use the vim QuickFix window, which is
 shared between all windows, set:
@@ -76,6 +81,8 @@ It is possible to set its maximum size (number of entries), default is 100:
 | &lt;Leader&gt;rw | -e -r --rename                   | Rename symbol under cursor                 |
 | &lt;Leader&gt;rv | -k -r                            | Find virtuals                              |
 | &lt;Leader&gt;rd | --diagnose                       | Diagnose file for warnings and errors      |
+| &lt;Leader&gt;rD | --diagnose-all                   | Diagnose all files in project              |
+| &lt;Leader&gt;rx | --fixits                         | Apply diagnostic fixits to current buffer  |
 | &lt;Leader&gt;rb | N/A                              | Jump to previous location                  |
 
 ## Unite sources
@@ -87,15 +94,17 @@ This plugin defines three Unite sources:
 * `rtags/project` - list/switch projects.
 
 ## Code completion
-Code completion functionality uses ```completefunc``` (i.e. CTRL-X CTRL-U). If ```completefunc```
-is set, vim-rtags will not override it with ```RtagsCompleteFunc```. This functionality is still
-unstable, but if you want to try it you will have to set ```completefunc``` by
+The ```omnifunc``` (i.e. CTRL-X CTRL-O) is overridden with ```RtagsCompleteFunc``` for cpp
+filetypes by default. This can be toggled using ```let g:rtagsCppOmnifunc = 0```.
+If ```g:rtagsCppOmnifunc``` is set to ```0``` then the  ```completefunc``` (i.e. CTRL-X CTRL-U)
+will be set instead, but only if it's not already used.
 
-    set completefunc=RtagsCompleteFunc
+Compatibility with [YouCompleteMe](https://valloric.github.io/YouCompleteMe/) is just a matter of
+disabling their built-in cpp completions and allowing vim-rtags to take over via their fallback to
+the ```omnifunc```.
 
-Also ```RtagsCompleteFunc``` can be used as omnifunc. For example, you can use
-such approach with [neocomplete](https://github.com/Shougo/neocomplete.vim)(for more details read it's docs):
-
+Compatibility with [neocomplete](https://github.com/Shougo/neocomplete.vim) can be achieved with
+(for more details read it's docs):
 ```
 function! SetupNeocompleteForCppWithRtags()
     " Enable heavy omni completion.
@@ -105,14 +114,13 @@ function! SetupNeocompleteForCppWithRtags()
         let g:neocomplete#sources#omni#input_patterns = {}
     endif
     let l:cpp_patterns='[^.[:digit:] *\t]\%(\.\|->\)\|\h\w*::'
-    let g:neocomplete#sources#omni#input_patterns.cpp = l:cpp_patterns 
+    let g:neocomplete#sources#omni#input_patterns.cpp = l:cpp_patterns
     set completeopt+=longest,menuone
 endfunction
 
 autocmd FileType cpp,c call SetupNeocompleteForCppWithRtags()
-
 ```
-Such config provides automatic calls, of omnicompletion on c and cpp entity accessors.
+Such config provides automatic calls of omnicompletion on c and cpp entity accessors.
 
 ### Current limitations
 * There is no support for overridden functions and methods
@@ -123,6 +131,8 @@ Such config provides automatic calls, of omnicompletion on c and cpp entity acce
 
 # Development
 Unit tests for some plugin functions can be found in ```tests``` directory.
-To run tests, execute:
-
+To run tests, execute (note `nose` is required for python tests):
+```
     $ vim tests/test_rtags.vim +UnitTest
+    $ nosetests tests
+```

--- a/doc/rtags.txt
+++ b/doc/rtags.txt
@@ -47,8 +47,8 @@ g:rtagsRdmCmd
     location if it is installed to a non standard location or the location
     doesn't appear in the PATH.
 
-                                                 *g:rtagsAutoLaunchRdm*
-                                                 *rtags-variable-auto-launch-rdm*
+                                            *g:rtagsAutoLaunchRdm*
+                                            *rtags-variable-auto-launch-rdm*
 g:rtagsAutoLaunchRdm
 
     Default: 0.
@@ -79,8 +79,8 @@ g:rtagsUseDefaultMappings
     Otherwise, no mappings are set up and custom mappings can be configured by
     a user.
 
-                                        *g:rtagsCppOmnifunc*
-                                        *rtags-variable-cpp-omnifunc*
+                                                *g:rtagsCppOmnifunc*
+                                                *rtags-variable-cpp-omnifunc*
 g:rtagsMinCharsForCommandCompletion
 
     Default: 4.
@@ -93,8 +93,9 @@ g:rtagsMinCharsForCommandCompletion
 g:rtagsCppOmnifunc
 
     Default: 1.
-    Override the vim completion |omnifunc| for the cpp filetype. If disabled, then
-    the |completefunc| will be used instead, but only if it's not already set.
+    Override the vim completion |omnifunc| for the cpp filetype. If disabled,
+    then the |completefunc| will be used instead, but only if it's not already
+    set.
 
                                 *g:rtagsMaxSearchResultWindowHeight*
                                 *rtags-variable-max-search-result-window-height*
@@ -104,22 +105,39 @@ g:rtagsMaxSearchResultWindowHeight
     Determines the maximum height of the search result window. When number of
     results is less than this parameter, the height is set to the number of
     results.
+                                            *g:rtagsAutoDiagnostics*
+                                            *rtags-variable-auto-diagnostics*
+g:rtagsAutoDiagnostics
+
+    Default: 1
+    If enabled then diagnostic gutter signs will be updated in the currently
+    active buffer automatically, and each line's diagnostic message will show
+    in the message window as the cursor moves through the file.
+
+                                *g:rtagsDiagnosticsPollingInterval*
+                                *rtags-variable-diagnostics-polling-interval*
+g:rtagsDiagnosticsPollingInterval
+
+    Default: 3000
+    If |g:rtagsAutoDiagnostics| is enabled, then poll for changes to the RTags
+    project with this interval and update diagnostic signs and lists if changes
+    are found.  Set to <=0 to disable polling. If disabled, updates to
+    diagnostics will be checked only after |CursorHold| and |BufEnter| events.
 
                                               *g:rtagsLog*
                                               *rtags-variable-rtags-log*
 g:rtagsLog
 
-    Default: empty
-    When set to filename, rtags will put its logs in that file.
+    Default: |tempname|
+    File to log vim-rtags output.
 
-                                              *g:rtagsAutoDiagnostics*
-                                              *rtags-variable-rtags-auto-diagnostics*
-g:rtagsAutoDiagnostics
+                                              *g:rtagsRdmLog*
+                                              *rtags-variable-rtags-rdm-log*
+g:rtagsRdmLog
 
-    Default: 1
-    If enabled then diagnostic gutter signs will be updated in the currently active
-    buffer automatically, and the diagnostic message will show in the message
-    window as the cursor moves through the file.
+    Default: |tempname|
+    If |g:rtagsAutoLaunchRdm| is enabled, then the RTags rdm daemon will log
+    its output to this file.
 
                                                                 *rtags-mappings*
 4. Mappings
@@ -222,9 +240,11 @@ g:rtagsAutoDiagnostics
                     |g:rtagsUseLocationList|). That is, all the errors and
                     warnings from rdm's clang build of the current project.
 
-                                                          *rtags-leader-rx*
-                                                            *rtags-FixIts*
-    <Leader>rx      Apply diagnostic clang fixits to the current buffer.
+                                                                *rtags-leader-rx*
+                                                                *rtags-FixIts*
+    <Leader>rx      Apply diagnostic clang fixits to the current buffer. Fixits
+                    are identified with "Fx" in the sign column, and are
+                    suffixed with "[FIXIT]" in the diagnostics lists.
 
 
                                                                 *rtags-commands*

--- a/doc/rtags.txt
+++ b/doc/rtags.txt
@@ -79,14 +79,22 @@ g:rtagsUseDefaultMappings
     Otherwise, no mappings are set up and custom mappings can be configured by
     a user.
 
-                                        *g:rtagsMinCharsForCommandCompletion*
-                                        *rtags-variable-min-chars-for-cmd-compl*
+                                        *g:rtagsCppOmnifunc*
+                                        *rtags-variable-cpp-omnifunc*
 g:rtagsMinCharsForCommandCompletion
 
     Default: 4.
     Minimum number of characters to be typed before argument completion is
     available for commands provided by the plugin or pluging mappings that
     require user input.
+
+                                        *g:rtagsMinCharsForCommandCompletion*
+                                        *rtags-variable-min-chars-for-cmd-compl*
+g:rtagsCppOmnifunc
+
+    Default: 1.
+    Override the vim completion |omnifunc| for the cpp filetype. If disabled, then
+    the |completefunc| will be used instead, but only if it's not already set.
 
                                 *g:rtagsMaxSearchResultWindowHeight*
                                 *rtags-variable-max-search-result-window-height*
@@ -103,6 +111,15 @@ g:rtagsLog
 
     Default: empty
     When set to filename, rtags will put its logs in that file.
+
+                                              *g:rtagsAutoDiagnostics*
+                                              *rtags-variable-rtags-auto-diagnostics*
+g:rtagsAutoDiagnostics
+
+    Default: 1
+    If enabled then diagnostic gutter signs will be updated in the currently active
+    buffer automatically, and the diagnostic message will show in the message
+    window as the cursor moves through the file.
 
                                                                 *rtags-mappings*
 4. Mappings
@@ -191,6 +208,24 @@ g:rtagsLog
                                                             *rtags-leader-rc*
                                                             *rtags-FindSubClasses*
     <Leader>rc      Find the subclasses of the class under the cursor.
+
+                                                            *rtags-leader-rd*
+                                                            *rtags-Diagnostics*
+    <Leader>rd      Show diagnostics for the current buffer in the location list,
+                    along withing diagnostic signs in the current window's
+                    gutter.
+
+                                                            *rtags-leader-rD*
+                                                            *rtags-DiagnosticsAll*
+    <Leader>rD      Show diagnostics for the whole project in the location or
+                    quickfix list (depending on the value of
+                    |g:rtagsUseLocationList|). That is, all the errors and
+                    warnings from rdm's clang build of the current project.
+
+                                                          *rtags-leader-rx*
+                                                            *rtags-FixIts*
+    <Leader>rx      Apply diagnostic clang fixits to the current buffer.
+
 
                                                                 *rtags-commands*
 5. Commands

--- a/doc/rtags.txt
+++ b/doc/rtags.txt
@@ -230,7 +230,7 @@ g:rtagsRdmLog
                                                             *rtags-leader-rd*
                                                             *rtags-Diagnostics*
     <Leader>rd      Show diagnostics for the current buffer in the location list,
-                    along withing diagnostic signs in the current window's
+                    along with diagnostic signs in the current window's
                     gutter.
 
                                                             *rtags-leader-rD*
@@ -257,6 +257,14 @@ g:rtagsRdmLog
         - RtagsIFindSymbols
         - RtagsIFindRefsByName
         - RtagsLoadCompilationDb
+
+                                                              *RtagsResetCaches*
+
+    RtagsResetCaches
+
+    Reset the buffer and RTags project cache.  This may be needed if you create
+    or modify the RTags project during a vim session.
+
 
                                                             *rtags-integrations*
 6. Integrations with other plugins

--- a/plugin/rtags.vim
+++ b/plugin/rtags.vim
@@ -1104,7 +1104,7 @@ endfunction
 
 " Prefer omnifunc, if enabled.
 if g:rtagsCppOmnifunc == 1
-    autocmd Filetype cpp setlocal omnifunc=RtagsCompleteFunc
+    autocmd Filetype cpp,c setlocal omnifunc=RtagsCompleteFunc
 " Override completefunc if it's available to be used.
 elseif &completefunc == ""
     set completefunc=RtagsCompleteFunc

--- a/plugin/rtags.vim
+++ b/plugin/rtags.vim
@@ -944,51 +944,6 @@ function! rtags#getCommandOutput(cmd_txt) abort
   return output
 endfunction
 
-"
-" This function assumes it is invoked from insert mode
-"
-function! rtags#CompleteAtCursor(wordStart, base)
-    let flags = "--synchronous-completions -l"
-    let file = expand("%:p")
-    let pos = getpos('.')
-    let line = pos[1]
-    let col = pos[2]
-
-    if index(['.', '::', '->'], a:base) != -1
-        let col += 1
-    endif
-
-    let rcRealCmd = rtags#getRcCmd()
-
-    exec "normal! \<Esc>"
-    let stdin_lines = join(getline(1, "$"), "\n").a:base
-    let offset = len(stdin_lines)
-
-    exec "startinsert!"
-    "    echomsg getline(line)
-    "    sleep 1
-    "    echomsg "DURING INVOCATION POS: ".pos[2]
-    "    sleep 1
-    "    echomsg stdin_lines
-    "    sleep 1
-    " sed command to remove CDATA prefix and closing xml tag from rtags output
-    let sed_cmd = "sed -e 's/.*CDATA\\[//g' | sed -e 's/.*\\/completions.*//g'"
-    let cmd = printf("%s %s %s:%s:%s --unsaved-file=%s:%s | %s", rcRealCmd, flags, file, line, col, file, offset, sed_cmd)
-    call rtags#Log("Command line:".cmd)
-
-    let result = split(system(cmd, stdin_lines), '\n\+')
-    "    echomsg "Got ".len(result)." completions"
-    "    sleep 1
-    call rtags#Log("-----------")
-    "call rtags#Log(result)
-    call rtags#Log("-----------")
-    return result
-    "    for r in result
-    "        echo r
-    "    endfor
-    "    call rtags#DisplayResults(result)
-endfunction
-
 function! s:Pyeval( eval_string )
   if g:rtagsPy == 'python3'
       return py3eval( a:eval_string )

--- a/plugin/rtags.vim
+++ b/plugin/rtags.vim
@@ -922,7 +922,9 @@ function! rtags#NotifyCursorMoved()
 endfunction
 
 function! rtags#Poll(timer)
-    call s:Pyeval("vimrtags.Buffer.current().on_poll()")
+    if &filetype == "cpp" || &filetype == "c"
+        call s:Pyeval("vimrtags.Buffer.current().on_poll()")
+    endif
     call timer_start(g:rtagsDiagnosticsPollingInterval, "rtags#Poll")
 endfunction
 

--- a/plugin/rtags.vim
+++ b/plugin/rtags.vim
@@ -59,7 +59,7 @@ endif
 
 if g:rtagsAutoLaunchRdm
     call system(g:rtagsRcCmd." -w")
-    if v:shell_error != 0 
+    if v:shell_error != 0
         call system(g:rtagsRdmCmd." --daemon > /dev/null")
     end
 end
@@ -96,6 +96,7 @@ if g:rtagsUseDefaultMappings == 1
     noremap <Leader>rC :call rtags#FindSuperClasses()<CR>
     noremap <Leader>rc :call rtags#FindSubClasses()<CR>
     noremap <Leader>rd :call rtags#Diagnostics()<CR>
+	noremap <Leader>rD :call rtags#DiagnosticsAll()<CR>
 endif
 
 let s:script_folder_path = escape( expand( '<sfile>:p:h' ), '\' )
@@ -534,7 +535,7 @@ function! rtags#saveLocation()
 endfunction
 
 function! rtags#pushToStack(location)
-    let jumpListLen = len(g:rtagsJumpStack) 
+    let jumpListLen = len(g:rtagsJumpStack)
     if jumpListLen > g:rtagsJumpStackMaxSize
         call remove(g:rtagsJumpStack, 0)
     endif
@@ -727,7 +728,7 @@ function! rtags#ExecuteHandlers(output, handlers)
                 return
             endtry
         endif
-    endfor 
+    endfor
 endfunction
 
 function! rtags#ExecuteThen(args, handlers)
@@ -880,6 +881,10 @@ function! rtags#Diagnostics()
     return s:Pyeval("vimrtags.get_diagnostics()")
 endfunction
 
+function! rtags#DiagnosticsAll()
+	return s:Pyeval("vimrtags.get_diagnostics_all()")
+endfunction
+
 "
 " This function assumes it is invoked from insert mode
 "
@@ -887,7 +892,7 @@ function! rtags#CompleteAtCursor(wordStart, base)
     let flags = "--synchronous-completions -l"
     let file = expand("%:p")
     let pos = getpos('.')
-    let line = pos[1] 
+    let line = pos[1]
     let col = pos[2]
 
     if index(['.', '::', '->'], a:base) != -1
@@ -932,7 +937,7 @@ function! s:Pyeval( eval_string )
       return pyeval( a:eval_string )
   endif
 endfunction
-    
+
 function! s:RcExecuteJobCompletion()
     call rtags#SetJobStateFinish()
     if ! empty(b:rtags_state['stdout']) && mode() == 'i'
@@ -1062,7 +1067,7 @@ endf
 "     - invoke completion through rc
 "     - filter out options that start with meth (in this case).
 "     - show completion options
-" 
+"
 "     Reason: rtags returns all options regardless of already type method name
 "     portion
 """

--- a/plugin/rtags.vim
+++ b/plugin/rtags.vim
@@ -27,8 +27,12 @@ if !exists("g:rtagsRdmCmd")
     let g:rtagsRdmCmd = "rdm"
 endif
 
-if !exists("g:rtagsRdmLogFile")
-    let g:rtagsRdmLogFile = "/dev/null"
+if !exists("g:rtagsLog")
+    let g:rtagsLog = tempname()
+endif
+
+if !exists("g:rtagsRdmLog")
+    let g:rtagsRdmLog = tempname()
 endif
 
 if !exists("g:rtagsAutoLaunchRdm")
@@ -72,7 +76,7 @@ endif
 if g:rtagsAutoLaunchRdm
     call system(g:rtagsRcCmd." -w")
     if v:shell_error != 0
-        call system(g:rtagsRdmCmd." --daemon  --log-timestamp --log-flush --log-file ".rtagsRdmLogFile)
+        call system(g:rtagsRdmCmd." --daemon  --log-timestamp --log-flush --log-file ".rtagsRdmLog)
     end
 end
 
@@ -130,9 +134,7 @@ call rtags#InitPython()
 " Logging routine
 """
 function! rtags#Log(message)
-    if exists("g:rtagsLog")
-        call writefile([string(a:message)], g:rtagsLog, "a")
-    endif
+    call writefile([strftime("%Y-%m-%d %H:%M:%S", localtime()) . " | vim | " . string(a:message)], g:rtagsLog, "a")
 endfunction
 
 "
@@ -491,7 +493,7 @@ function! rtags#JumpToHandler(results, args)
     if len(results) >= 0 && open_opt != g:SAME_WINDOW
         call rtags#cloneCurrentBuffer(open_opt)
     endif
-
+    call rtags#Log("JumpTo results with ".json_encode(a:args).": ".json_encode(results))
     if len(results) > 1
         call rtags#DisplayResults(results)
     elseif len(results) == 1
@@ -507,6 +509,8 @@ function! rtags#JumpToHandler(results, args)
         if rtags#jumpToLocation(jump_file, lnum, col)
             normal! zz
         endif
+    else
+        echom "Failed to jump - cannot follow symbol"
     endif
 
 endfunction

--- a/plugin/rtags.vim
+++ b/plugin/rtags.vim
@@ -1152,7 +1152,9 @@ command! RtagsResetCaches call s:Pyeval('vimrtags.reset_caches()')
 if g:rtagsAutoLaunchRdm
     call system(g:rtagsRcCmd." -w")
     if v:shell_error != 0
-        call system(g:rtagsRdmCmd." --daemon  --log-timestamp --log-flush --log-file ".rtagsRdmLog)
+        let s:cmd = g:rtagsRdmCmd." --daemon  --log-timestamp --log-flush --log-file ".g:rtagsRdmLog
+        call rtags#Log("Starting RDM: ".s:cmd)
+        call system(s:cmd)
     end
 end
 

--- a/plugin/rtags.vim
+++ b/plugin/rtags.vim
@@ -882,6 +882,7 @@ function! rtags#Diagnostics()
 endfunction
 
 function! rtags#DiagnosticsAll()
+	let s:file = expand("%:p")
 	return s:Pyeval("vimrtags.get_diagnostics_all()")
 endfunction
 

--- a/plugin/rtags.vim
+++ b/plugin/rtags.vim
@@ -1133,6 +1133,9 @@ command! -nargs=1 -complete=dir RtagsLoadCompilationDb call rtags#LoadCompilatio
 " The most commonly used find operation
 command! -nargs=1 -complete=customlist,rtags#CompleteSymbols Rtag RtagsIFindSymbols <q-args>
 
+" Reset all Python caches - maybe useful if the RTags project has been messed with
+" after the vim session has started.
+command! RtagsResetCaches call s:Pyeval('vimrtags.reset_caches()')
 
 if g:rtagsAutoLaunchRdm
     call system(g:rtagsRcCmd." -w")

--- a/plugin/vimrtags.py
+++ b/plugin/vimrtags.py
@@ -5,18 +5,32 @@ import io
 import os
 import sys
 import tempfile
-
+import re
 import logging
-tempdir = tempfile.gettempdir()
-logfile = '%s/vim-rtags-python.log' % tempdir
-logging.basicConfig(filename=logfile, level=logging.DEBUG)
+from time import time
+
+
+logfile = '%s/vim-rtags-python.log' % tempfile.gettempdir()
+loglevel = logging.DEBUG
+logger = logging.getLogger(__name__)
+
+
+def configure_logger():
+    handler = logging.FileHandler(logfile)
+    formatter = logging.Formatter("%(asctime)s | %(levelname)s | %(message)s")
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    logger.setLevel(loglevel)
+
+configure_logger()
+
 
 def get_identifier_beginning():
     line = vim.eval('s:line')
     column = int(vim.eval('s:start'))
 
-    logging.debug(line)
-    logging.debug(column)
+    logger.debug(line)
+    logger.debug(column)
 
     while column >= 0 and (line[column].isalnum() or line[column] == '_'):
         column -= 1
@@ -30,10 +44,11 @@ def run_rc_command(arguments, content = None):
     encoding = 'utf-8'
     out = None
     err = None
+    logger.debug("RTags command: %s" % cmdline.split())
     if sys.version_info.major == 3 and sys.version_info.minor >= 5:
         r = subprocess.run(
             cmdline.split(),
-            input = content,
+            input = content and content.encode("utf-8"),
             stdout = subprocess.PIPE,
             stderr = subprocess.PIPE
         )
@@ -66,10 +81,10 @@ def run_rc_command(arguments, content = None):
         out, err = r.communicate(input=content)
 
     if r.returncode != 0:
-        logging.debug(err)
+        logger.debug(err)
         return None
     elif "is not indexed" in out:
-        logging.debug(out)
+        logger.debug(out)
         return None
 
     return out
@@ -80,7 +95,7 @@ def get_rtags_variable(name):
 
 def parse_completion_result(data):
     result = json.loads(data)
-    logging.debug(result)
+    logger.debug(result)
     completions = []
 
     for c in result['completions']:
@@ -99,7 +114,7 @@ def parse_completion_result(data):
       elif k == 'TypedefDecl' or k == 'StructDecl' or k == 'EnumConstantDecl':
         kind = 't'
 
-      match = {'menu': c['completion'], 'word': c['completion'], 'kind': kind}
+      match = {'menu': " ".join([c['parent'], c['signature']]), 'word': c['completion'], 'kind': kind}
       completions.append(match)
 
     return completions
@@ -111,7 +126,7 @@ def send_completion_request():
     prefix = vim.eval('s:prefix')
 
     for buffer in vim.buffers:
-        logging.debug(buffer.name)
+        logger.debug(buffer.name)
         if buffer.name == filename:
             lines = [x for x in buffer]
             content = '\n'.join(lines[:line - 1] + [lines[line - 1] + prefix] + lines[line:])
@@ -122,6 +137,7 @@ def send_completion_request():
                 cmd += ' --code-complete-prefix %s' % prefix
 
             content = run_rc_command(cmd, content)
+            logger.debug("Got completion: %s" % content)
             if content == None:
                 return None
 
@@ -129,100 +145,552 @@ def send_completion_request():
 
     assert False
 
-def display_locations(errors, buffer):
-    if len(errors) == 0:
-        return
 
-    errors = sorted(errors, key=lambda e: e['type'])
-    error_data = json.dumps(errors)
-    max_height = int(get_rtags_variable('MaxSearchResultWindowHeight'))
-    height = min(max_height, len(errors))
+class Buffer(object):
+    _cache = {}
+    _cache_last_cleaned = time()
+    _CACHE_CLEAN_PERIOD = 30
+    _DIAGNOSTICS_CHECK_PERIOD = 5
+    _DIAGNOSTICS_LIST_TITLE = "RTags diagnostics"
+    _DIAGNOSTICS_ALL_LIST_TITLE = "RTags diagnostics for all files"
+    _FIXITS_LIST_TITLE = "RTags fixits applied"
 
-    if int(get_rtags_variable('UseLocationList')) == 1:
-        vim.eval('setloclist(%d, %s)' % (buffer.number, error_data))
+    @staticmethod
+    def current():
+        return Buffer.get(vim.current.buffer.number)
+
+    @staticmethod
+    def find(name):
+        """ Find a Buffer by vim buffer (file)name.
+        """
+        for buffer in vim.buffers:
+            if buffer.name == name:
+                return Buffer.get(buffer.number)
+        else:
+            return None
+
+    @staticmethod
+    def get(id_):
+        """ Get a Buffer wrapping a vim buffer, by id_.
+
+            Create the Buffer if necessary.
+        """
+        # Get from cache or create if it's not there.
+        buff = Buffer._cache.get(id_)
+        if buff is not None:
+            return buff
+
+        # Periodically clean closed buffers
+        if time() - Buffer._cache_last_cleaned > Buffer._CACHE_CLEAN_PERIOD:
+            logger.debug("Cleaning invalid buffers")
+            for id_ in Buffer._cache.keys():
+                if not Buffer._cache[id_]._vimbuffer.valid:
+                    logger.debug("Cleaning invalid buffer %s" % id_)
+                    del Buffer._cache[id_]
+            Buffer._cache_last_cleaned = time()
+
+        buff = Buffer(vim.buffers[id_])
+        Buffer._cache[id_] = buff
+        return buff
+
+    @staticmethod
+    def show_all_diagnostics():
+        """ Get all diagnostics for all files and show in quickfix list.
+        """
+        # Get the diagnostics from rtags.
+        content = run_rc_command('--diagnose-all  --synchronous-diagnostics --json')
+        if content is None:
+            return error('Failed to get diagnostics')
+        data = json.loads(content)
+
+        # Construct Diagnostic objects from rtags errors.
+        diagnostics = []
+        for filename, errors in data['checkStyle'].items():
+            diagnostics += Diagnostic.from_rtags_errors(filename, errors)
+
+        if not diagnostics:
+            return message("No errors to show")
+
+        # Convert list of Diagnostic objects to quickfix-compatible dict.
+        height, lines = Diagnostic.to_qlist_errors(diagnostics)
+
+        # Show diagnostics in location list or quickfix list, depending on user preference.
+        if int(get_rtags_variable('UseLocationList')) == 1:
+            vim.eval(
+                'setloclist(%d, [], " ", {"items": %s, "title": "%s"})'
+                % (vim.current.window.number, lines, Buffer._DIAGNOSTICS_ALL_LIST_TITLE)
+            )
+            vim.command('lopen %d' % height)
+        else:
+            vim.eval(
+                'setqflist([], " ", {"items": %s, "title": "%s"})'
+                % (lines, Buffer._DIAGNOSTICS_ALL_LIST_TITLE)
+            )
+            vim.command('copen %d' % height)
+
+    def __init__(self, buffer):
+        self._vimbuffer = buffer
+        self._signs = []
+        self._diagnostics = {}
+        self._last_diagnostics_time = 0
+        self._line_num_last = -1
+        self._is_line_diagnostic_shown = False
+        self._is_dirty = False
+
+        self._project = Project.get(self._vimbuffer.name)
+
+    def on_write(self):
+        self._is_dirty = False
+
+    def on_edit(self):
+        """ Mark buffer dirty, potentially flagging a reindex using unsaved content.
+        """
+        if self._project is None:
+            return
+        self._is_dirty = True
+
+    def on_idle(self):
+        """ Reindex or update diagnostics for this buffer.
+        """
+        if self._project is None:
+            return
+
+        if self._is_dirty:
+            # `TextChange` autocmd also triggers just by switching buffers, so we have to be sure.
+            is_really_dirty = vim.eval('getbufvar(%d, "&mod")' % self._vimbuffer.number)
+        else:
+            is_really_dirty = False
+
+        if is_really_dirty:
+            # Reindex dirty buffer - no point refreshing diagnostics at this point.
+            logger.debug("Buffer %s needs dirty reindex" % self._vimbuffer.number)
+            self._rtags_dirty_reindex()
+            # No point getting diagnostics any time soon.
+            self._last_diagnostics_time = time()
+
+        elif self._last_diagnostics_time < self._project.last_updated_time():
+            # Update diagnostics signs/list.
+            logger.debug(
+                "Project updated, checking for updated diagnostics for %s" % self._vimbuffer.name
+            )
+            self._update_diagnostics()
+
+    def on_cursor_moved(self):
+        """ Print diagnostic info for current line
+        """
+        if self._project is None:
+            return
+        line_num = vim.current.window.cursor[0]
+        if line_num != self._line_num_last:
+            self._line_num_last = line_num
+            diagnostic = self._diagnostics.get(line_num)
+            if diagnostic is not None:
+                print(diagnostic.text)
+                self._is_line_diagnostic_shown = True
+            elif self._is_line_diagnostic_shown:
+                # If there is no diagnostic for this line, clear the message.
+                print("")
+                # Make sure we only clear the message when we've recently shown one, so we don't
+                # splat other plugins messages.
+                self._is_line_diagnostic_shown = False
+
+    def show_diagnostics_list(self):
+        """ Show diagnostics for this buffer in location/quickfix list.
+
+            Diagnostics are updated before being displayed, just in case.
+        """
+        if self._project is None:
+            return invalid_buffer_message(self._vimbuffer.name)
+
+        self._update_diagnostics(open_loclist=True)
+        if not self._diagnostics:
+            return message("No errors to display")
+
+    def apply_fixits(self):
+        """ Fetch fixits from rtags, apply them, and show changed lines in quickfix/location list.
+        """
+        if self._project is None:
+            return invalid_buffer_message(self._vimbuffer.name)
+        # Not safe to apply fixits if file is not indexed, make extra sure it is.
+        if (
+            self._rtags_is_reindexing() or (
+                int(vim.eval("g:rtagsAutoDiagnostics")) and
+                self._last_diagnostics_time < self._project.last_updated_time()
+            )
+        ):
+            return message(
+                "File is currently reindexing, so fixits are unsafe, please try again shortly"
+            )
+
+        # Get the fixits from rtags.
+        content = run_rc_command('--fixits %s' % self._vimbuffer.name)
+        if content is None:
+            return error("Failed to fetch fixits")
+        content = content.strip()
+        if not content:
+            return message("No fixits to apply to this file")
+
+        logger.debug("Fixits found:\n%s" % content)
+        fixits = content.split('\n')
+        lines = []
+
+        # Loop over fixits applying each in turn and record what was done for qlist/loclist.
+        for i, fixit in enumerate(fixits):
+            # Regex parse the fixits.
+            fixit = re.match("^(\d+):(\d+) (\d+) (.+)$", fixit)
+            if fixit is None:
+                continue
+            line_num = int(fixit.group(1))
+            line_idx = line_num - 1
+            char_num = int(fixit.group(2))
+            char_idx = char_num - 1
+            length = int(fixit.group(3))
+            text = fixit.group(4)
+
+            # Edit the buffer to apply the fixit.
+            self._vimbuffer[line_idx] = (
+                self._vimbuffer[line_idx][:char_idx] + text +
+                self._vimbuffer[line_idx][char_idx + length:]
+            )
+            # Construct quickfix list compatible dict.
+            lines.append({
+                'lnum': line_num, 'col': char_num, 'text': text, 'filename': self._vimbuffer.name
+            })
+
+        # Calculate height of quickfix list.
+        max_height = int(get_rtags_variable('MaxSearchResultWindowHeight'))
+        height = min(max_height, len(lines))
+        lines = json.dumps(lines)
+
+        # Render lines fixed to location list and open it.
+        vim.eval(
+            'setloclist(%d, [], " ", {"items": %s, "title": "%s"})'
+            % (vim.current.window.number, lines, Buffer._FIXITS_LIST_TITLE)
+        )
         vim.command('lopen %d' % height)
-    else:
-        vim.eval('setqflist(%s)' % error_data)
-        vim.command('copen %d' % height)
 
-def find_buffer(filename=None):
-    if filename is None:
-        filename = vim.eval('s:file')
-    for buffer in vim.buffers:
-        if buffer.name == filename:
-            return buffer
-    else:
-        return None
+        message("Fixits applied")
 
-def display_diagnostics_results(data, buffer):
-    data = json.loads(data)
-    logging.debug(data)
+    def _place_signs(self):
+        """ Add gutter indicator signs next to lines that have diagnostics.
+        """
+        self._reset_signs()
+        used_ids = Sign.used_ids(self._vimbuffer.number)
+        for diagnostic in self._diagnostics.values():
+            self._place_sign(diagnostic.line_num, diagnostic.type, used_ids)
 
-    check_style = data['checkStyle']
-    vim.command('sign unplace *')
+    def _rtags_dirty_reindex(self):
+        """ Reindex unsaved buffer contents in rtags.
+        """
+        content = "\n".join([x for x in self._vimbuffer])
+        result = run_rc_command(
+            '--json --reindex {0} --unsaved-file={0}:{1}'.format(
+                self._vimbuffer.name, len(content)
+            ), content
+        )
+        self._is_dirty = False
+        logger.debug("Rtags responded to reindex request: %s" % result)
 
-    # There are no errors
-    if check_style == None:
-        return message('No errors found')
+    def _rtags_is_reindexing(self):
+        """ Check if rtags has this buffer queued for reindexing.
+        """
+        # Unfortunately, --check-reindex doesn't work if --unsaved-file used with --reindex.
+        content = run_rc_command('--status jobs')
+        if content is None:
+            return error("Failed to check if %s needs reindex" % self._vimbuffer.name)
+        return self._vimbuffer.name in content
 
-    quickfix_errors = []
+    def _update_diagnostics(self, open_loclist=False):
+        """ Fetch new diagnostics from rtags and update gutter signs and location list.
+        """
+        # Reset current diagnostics.
+        self._diagnostics = {}
+        # Reset diagnostic timer, so we don't query too often.
+        self._last_diagnostics_time = time()
 
-    vim.command('sign define fixit text=F texthl=FixIt')
-    vim.command('sign define warning text=W texthl=Warning')
-    vim.command('sign define error text=E texthl=Error')
+        # Get the diagnostics from rtags.
+        content = run_rc_command(
+            '--diagnose %s --synchronous-diagnostics --json' % self._vimbuffer.name
+        )
+        if content is None:
+            return error('Failed to get diagnostics for "%s"' % self._vimbuffer.name)
+        logger.debug("Diagnostics for %s from rtags: %s" % (self._vimbuffer.name, content))
+        data = json.loads(content)
+        errors = data['checkStyle'][self._vimbuffer.name]
 
-    for filename, errors in check_style.items():
-        for i, e in enumerate(errors):
+        # Construct Diagnostic objects from rtags response, and cache keyed by line number.
+        for diagnostic in Diagnostic.from_rtags_errors(self._vimbuffer.name, errors):
+            self._diagnostics[diagnostic.line_num] = diagnostic
+
+        # Update location list with new diagnostics, if ours is currently at the top of the stack.
+        self._update_loclist(open_loclist)
+        # Place gutter signs next to lines with diagnostics to show.
+        self._place_signs()
+        # Flag that we've changed cursor line to trick into rerendering diagnostic message.
+        self._line_num_last = -1
+        self.on_cursor_moved()
+
+    def _update_loclist(self, force):
+        """ Update the location list for the current buffer with updated diagnostics.
+
+            Unfortunately, there doesn't seem to be a simple way to know if the location list for
+            the current window is actually visible, so just always update it if it's at the top of
+            the stack.
+
+            If `force` is given then always update, and show, the location list.
+        """
+        # Only bother updating if the active window is showing this buffer.
+        if self._vimbuffer.number != vim.current.window.buffer.number:
+            return
+        # Get title of this buffer's location list, if available.
+        loclist_info = vim.eval(
+            'getloclist(%s, {"title": 0})' % vim.current.window.number
+        )
+        loclist_title = loclist_info.get('title')
+        # If the title matches our location list, then we want to update, otherwise either create
+        # or quit.
+        is_rtags_loclist_open = loclist_title == Buffer._DIAGNOSTICS_LIST_TITLE
+        if not force and not is_rtags_loclist_open:
+            logger.debug("Location list not open (title=%s) so not updating it" % loclist_title)
+            return
+
+        logger.debug("Updating location list with %s diagnostics" % len(self._diagnostics))
+
+        # Get our diagnostics as quicklist/loclist formatted dict.
+        height, lines = Diagnostic.to_qlist_errors(self._diagnostics.values())
+        # If our loclist is open, we want to replace the contents, otherwise create a new loclist.
+        if is_rtags_loclist_open:
+            action = "r"
+        else:
+            action = " "
+
+        # Create/replace the loclist with our diagnostics.
+        vim.eval(
+            'setloclist(%d, [], "%s", {"items": %s, "title": "%s"})'
+            % (vim.current.window.number, action, lines, Buffer._DIAGNOSTICS_LIST_TITLE)
+        )
+
+        # If we want to open the loclist and we have something to show, then open it.
+        if force:
+            if height > 0:
+                vim.command('lopen %d' % height)
+            else:
+                message("No errors to show")
+
+    def _place_sign(self, line_num, name, used_ids):
+        """ Create, place and remember a diagnostic gutter sign.
+        """
+        # Get last sign ID that we used in this buffer.
+        id_ = self._signs and self._signs[-1].id or Sign.START_ID
+        # We need a new ID.
+        id_ += 1
+        # Other plugins could have added signs, so make sure we don't splat them.
+        while id_ in used_ids:
+            id_ += 1
+        logger.debug(
+            'Appending sign %s on line %s with id %s in buffer %s (%s)' % (
+                name, line_num, id_, self._vimbuffer.number, self._vimbuffer.name
+            )
+        )
+        # Construct a Sign, which will also render it in the buffer, and cache it.
+        self._signs.append(Sign(id_, line_num, name, self._vimbuffer.number))
+
+    def _reset_signs(self):
+        """ Remove all diagnostic signs from buffer gutter and reset our cache of them.
+        """
+        for sign in self._signs:
+            sign.unplace()
+        self._signs = []
+
+
+class Project(object):
+    """ Wrapper for an rtags "project".
+
+        Used to track last modification time of rtags index database.
+    """
+
+    _rtags_data_dir = None
+    _cache = {}
+
+    @staticmethod
+    def get(filepath):
+        # Get rtags project that given file belongs to, if any.
+        project_root = run_rc_command('--project %s' % filepath)
+        # If rc command line failed, then assume nothing to do.
+        if project_root is None:
+            return None
+        # If no rtags project, then nothing to do.
+        if project_root.startswith("No matches"):
+            logger.debug("No rtags project found for %s" % filepath)
+            return None
+
+        # Lazily find the location of the rtags database. We check the modification date of the DB
+        # to decide if/when we need to update our cache.
+        if Project._rtags_data_dir is None:
+            info = run_rc_command('--status info')
+            logger.debug("RTags info:\n%s" % info)
+            match = re.search("^dataDir: (.*)$", info, re.MULTILINE)
+            Project._rtags_data_dir = match.group(1)
+            logger.info("RTags data directory set to %s" % Project._rtags_data_dir)
+
+        project_root = project_root.strip()
+        # Get the project for the given file from the cache, if available.
+        project = Project._cache.get(project_root)
+        if project is not None:
+            return project
+
+        # Create a new Project and cache it.
+        logger.info("Found RTags project %s for %s" % (project_root, filepath))
+        project = Project(project_root)
+        Project._cache[project_root] = project
+        return project
+
+    def __init__(self, project_root):
+        self._project_root = project_root
+        # Calculate the path of project database in the RTags data directory.
+        self._db_path = os.path.join(
+            Project._rtags_data_dir, project_root.replace("/", "_"), "project"
+        )
+        logger.debug("Project %s db path set to %s" % (self._project_root, self._db_path))
+
+    def last_updated_time(self):
+        """ Unix timestamp when the rtags database was last updated.
+        """
+        return os.path.getmtime(self._db_path)
+
+
+class Diagnostic(object):
+
+    @staticmethod
+    def from_rtags_errors(filename, errors):
+        diagnostics = []
+        for e in errors:
             if e['type'] == 'skipped':
                 continue
-
             # strip error prefix
             s = ' Issue: '
             index = e['message'].find(s)
             if index != -1:
                 e['message'] = e['message'][index + len(s):]
-                error_type = 'E' if e['type'] == 'error' else 'W'
-                quickfix_errors.append({'lnum': e['line'], 'col': e['column'],
-                    'nr': i, 'text': e['message'], 'filename': filename,
-                    'type': error_type})
-                if find_buffer(filename) is not None:
-                    cmd = 'sign place %d line=%s name=%s file=%s' % (
-                        i + 1, e['line'], e['type'], filename)
-                    vim.command(cmd)
+                diagnostics.append(
+                    Diagnostic(filename, e['line'], e['column'], e['type'], e['message'])
+                )
+        return diagnostics
 
-    # There are no errors
-    if not quickfix_errors:
-        return message('No errors found')
-    else:
-        display_locations(quickfix_errors, buffer)
+    @staticmethod
+    def to_qlist_errors(diagnostics):
+        num_diagnostics = len(diagnostics)
+        lines = [d._to_qlist_dict() for d in diagnostics]
+        lines = sorted(lines, key=lambda d: (d['type'], d['filename'], d['lnum']))
+        lines = json.dumps(lines)
 
-def get_diagnostics():
-    buffer = find_buffer()
-    is_modified = bool(int((vim.eval('getbufvar(%d, "&mod")' % buffer.number))))
-    cmd = '--diagnose %s --synchronous-diagnostics --json' % buffer.name
+        max_height = int(get_rtags_variable('MaxSearchResultWindowHeight'))
+        height = min(max_height, num_diagnostics)
 
-    content = ''
-    if is_modified:
-        content = '\n'.join([x for x in buffer])
-        cmd += ' --unsaved-file=%s:%d' % (filename, len(content))
+        return height, lines
 
-    content = run_rc_command(cmd, content)
-    if content == None:
-        return error('Failed to get diagnostics for "%s"' % buffer.name)
+    def __init__(self, filename, line_num, char_num, type_, text):
+        self.filename = filename
+        self.line_num = line_num
+        self.char_num = char_num
+        self.type = type_
+        self.text = text
 
-    display_diagnostics_results(content, buffer)
+    def _to_qlist_dict(self):
+        error_type = self.type[0].upper()
+        return {
+            'lnum': self.line_num, 'col': self.char_num, 'text': self.text,
+            'filename': self.filename, 'type': error_type
+        }
 
-    return 0
 
-def get_diagnostics_all():
-    content = run_rc_command('--diagnose-all  --synchronous-diagnostics --json')
-    if content is None:
-        return error('Failed to get diagnostics')
-    display_diagnostics_results(content, find_buffer())
-    return 0
+class Sign(object):
+    START_ID = 2000
+    _is_signs_defined = False
+
+    @staticmethod
+    def _define_signs():
+        """ Define highlight group and gutter signs for diagnostics.
+
+            Must do this lazily because other plugins can go and change SignColumn highlight
+            group on initialisation (e.g. gitgutter).
+        """
+        logger.debug("Defining gutter diagnostic signs")
+        def get_bgcolour(group):
+            logger.debug("Scanning highlight group %s for background colour" % group)
+            output = get_command_output("highlight %s" % group)
+            logger.debug("Highlight group output:\n%s" % output)
+            match = re.search(r"links to (\S+)", output)
+            if match is None:
+                ctermbg_match = re.search(r"ctermbg=(\S+)", output)
+                guibg_match = re.search(r"guibg=(\S+)", output)
+                return (
+                    ctermbg_match and ctermbg_match.group(1),
+                    guibg_match and guibg_match.group(1)
+                )
+            return get_bgcolour(match.group(1))
+
+        ctermbg, guibg = get_bgcolour("SignColumn")
+        bg = ""
+        if guibg is not None:
+            bg += " guibg=%s" % guibg
+        if ctermbg is not None:
+            bg += " ctermbg=%s" % ctermbg
+
+        logger.debug("Background colours are %s, %s" % (ctermbg, guibg))
+        vim.command(
+            "highlight rtags_fixit guifg=#ff00ff ctermfg=5 %s" % bg
+        )
+        vim.command(
+            "highlight rtags_warning guifg=#fff000 ctermfg=11 %s" % bg
+        )
+        vim.command(
+            "highlight rtags_error guifg=#ff0000 ctermfg=1 %s" % bg
+        )
+
+        vim.command("sign define rtags_fixit text=Fx texthl=rtags_fixit")
+        vim.command("sign define rtags_warning text=W texthl=rtags_warning")
+        vim.command("sign define rtags_error text=E texthl=rtags_error")
+        Sign._is_signs_defined = True
+
+    @staticmethod
+    def used_ids(buffer_num):
+        signs_txt = get_command_output("sign place buffer=%s" % buffer_num)
+        sign_ids = set()
+        for sign_match in re.finditer("id=(\d+)", signs_txt):
+            sign_ids.add(int(sign_match.group(1)))
+        return sign_ids
+
+    def __init__(self, id, line_num, name, buffer_num):
+        self.id = id
+        self._vimbuffer_num = buffer_num
+        if not Sign._is_signs_defined:
+            Sign._define_signs()
+        vim.command(
+            'sign place %d line=%s name=rtags_%s buffer=%s' % (
+                self.id, line_num, name, self._vimbuffer_num
+            )
+        )
+
+    def unplace(self):
+        vim.command('sign unplace %s buffer=%s' % (self.id, self._vimbuffer_num))
+
+
+def get_command_output(cmd_txt):
+    return vim.eval('rtags#getCommandOutput("%s")' % cmd_txt)
+
+
+def invalid_buffer_message(filename):
+    print(
+        "No RTags project for file: %s" % filename
+        if filename else "Please select a file buffer and try again"
+    )
+
 
 def error(msg):
-    message('%s: see log file at "%s" for more information' % (msg, logfile))
+    message("""%s: see log file at" "%s" for more information""" % (msg, logfile))
+
 
 def message(msg):
-    vim.command("echom '%s'" % msg)
+    vim.command("""echom '%s'""" % msg)
+

--- a/plugin/vimrtags.py
+++ b/plugin/vimrtags.py
@@ -102,15 +102,20 @@ def parse_completion_result(data):
         kind = ''
         if k == 'FunctionDecl' or k == 'FunctionTemplate':
             kind = 'f'
+            description = _completion_description(c, ['parent', 'signature'])
         elif k == 'CXXMethod' or k == 'CXXConstructor':
             kind = 'm'
+            description = _completion_description(c, ['parent', 'signature'])
         elif k == 'VarDecl':
             kind = 'v'
+            description = _completion_description(c, ['parent', 'signature'])
         elif k == 'macro definition':
             kind = 'd'
+            description = _completion_description(c, ['signature'])
         elif k == 'EnumDecl':
             kind = 'e'
-        elif k == 'TypedefDecl' or k == 'StructDecl' or k == 'EnumConstantDecl':
+            description = _completion_description(c, ['parent'])
+        elif k in ('TypedefDecl', 'StructDecl', 'EnumConstantDecl', 'ClassDecl', 'FieldDecl'):
             kind = 't'
             description = _completion_description(c, ['parent'])
         else:
@@ -120,6 +125,12 @@ def parse_completion_result(data):
         completions.append(match)
 
     return completions
+
+
+def _completion_description(completion, fields):
+    fields = [field for field in fields if completion[field] != completion['completion']]
+    fields = ['completion'] + fields + ['brief_comment']
+    return " -- ".join(filter(None, [completion[field] for field in fields]))
 
 
 def send_completion_request():

--- a/plugin/vimrtags.py
+++ b/plugin/vimrtags.py
@@ -1,3 +1,4 @@
+from __future__ import print_function  # For unit tests
 import vim
 import json
 import subprocess

--- a/plugin/vimrtags.py
+++ b/plugin/vimrtags.py
@@ -115,9 +115,12 @@ def parse_completion_result(data):
             kind = 'e'
         elif k == 'TypedefDecl' or k == 'StructDecl' or k == 'EnumConstantDecl':
             kind = 't'
+            description = _completion_description(c, ['parent'])
+        else:
+            description = _completion_description(c, [])
 
-    match = {'menu': " ".join([c['parent'], c['signature']]), 'word': c['completion'], 'kind': kind}
-    completions.append(match)
+        match = {'menu': description, 'word': c['completion'], 'kind': kind}
+        completions.append(match)
 
     return completions
 
@@ -134,11 +137,13 @@ def send_completion_request():
             lines = [x for x in buffer]
             content = '\n'.join(lines[:line - 1] + [lines[line - 1] + prefix] + lines[line:])
 
-            cmd = '--synchronous-completions -l %s:%d:%d --unsaved-file=%s:%d --json' % (
-                filename, line, column, filename, len(content)
-            )
+            cmd = [
+                    '--synchronous-completions', '-l', '%s:%d:%d' % (filename, line, column),
+                    '--unsaved-file=%s:%d' % (filename, len(content)), '--json'
+                ]
+
             if len(prefix) > 0:
-                cmd += ' --code-complete-prefix %s' % prefix
+                cmd += ['--code-complete-prefix', prefix]
 
             content = run_rc_command(cmd, content)
             logger.debug("Got completion: %s" % content)

--- a/plugin/vimrtags.py
+++ b/plugin/vimrtags.py
@@ -514,6 +514,9 @@ class Project(object):
 
     @staticmethod
     def get(filepath):
+        # A blank filename (e.g. loclist) has no project.
+        if not filepath:
+            return None
         # Get rtags project that given file belongs to, if any.
         project_root = run_rc_command('--project %s' % filepath)
         # If rc command line failed, then assume nothing to do.

--- a/plugin/vimrtags.py
+++ b/plugin/vimrtags.py
@@ -8,6 +8,8 @@ import logging
 from time import time
 
 
+print = print  # For unit tests
+
 loglevel = logging.DEBUG
 logger = logging.getLogger(__name__)
 

--- a/plugin/vimrtags.py
+++ b/plugin/vimrtags.py
@@ -42,7 +42,7 @@ def run_rc_command(arguments, content = None):
             out = out.decode(encoding)
         if not err is None:
             err = err.decode(encoding)
-
+o
     elif sys.version_info.major == 3 and sys.version_info.minor < 5:
         r = subprocess.Popen(
             cmdline.split(),

--- a/plugin/vimrtags.py
+++ b/plugin/vimrtags.py
@@ -133,7 +133,6 @@ def parse_completion_result(data):
 def _completion_description(completion, fields):
     fields += ['brief_comment']
     fields = [field for field in fields if completion[field] != completion['completion']]
-    fields = ['completion'] + fields
     return " -- ".join(filter(None, [completion[field] for field in fields]))
 
 

--- a/plugin/vimrtags.py
+++ b/plugin/vimrtags.py
@@ -1,7 +1,6 @@
 import vim
 import json
 import subprocess
-import io
 import os
 import sys
 import tempfile
@@ -22,6 +21,7 @@ def configure_logger():
     logger.addHandler(handler)
     logger.setLevel(loglevel)
 
+
 configure_logger()
 
 
@@ -37,7 +37,8 @@ def get_identifier_beginning():
 
     return column + 1
 
-def run_rc_command(arguments, content = None):
+
+def run_rc_command(arguments, content=None):
     rc_cmd = os.path.expanduser(vim.eval('g:rtagsRcCmd'))
     cmdline = [rc_cmd] + arguments
 
@@ -48,14 +49,14 @@ def run_rc_command(arguments, content = None):
     if sys.version_info.major == 3 and sys.version_info.minor >= 5:
         r = subprocess.run(
             cmdline,
-            input = content and content.encode("utf-8"),
-            stdout = subprocess.PIPE,
-            stderr = subprocess.PIPE
+            input=content and content.encode("utf-8"),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE
         )
         out, err = r.stdout, r.stderr
-        if not out is None:
+        if out is not None:
             out = out.decode(encoding)
-        if not err is None:
+        if err is not None:
             err = err.decode(encoding)
 
     elif sys.version_info.major == 3 and sys.version_info.minor < 5:
@@ -67,9 +68,9 @@ def run_rc_command(arguments, content = None):
             stderr=subprocess.STDOUT
         )
         out, err = r.communicate(input=content.encode(encoding))
-        if not out is None:
+        if out is not None:
             out = out.decode(encoding)
-        if not err is None:
+        if err is not None:
             err = err.decode(encoding)
     else:
         r = subprocess.Popen(
@@ -93,31 +94,33 @@ def run_rc_command(arguments, content = None):
 def get_rtags_variable(name):
     return vim.eval('g:rtags' + name)
 
+
 def parse_completion_result(data):
     result = json.loads(data)
     logger.debug(result)
     completions = []
 
     for c in result['completions']:
-      k = c['kind']
-      kind = ''
-      if k == 'FunctionDecl' or k == 'FunctionTemplate':
-        kind = 'f'
-      elif k == 'CXXMethod' or k == 'CXXConstructor':
-        kind = 'm'
-      elif k == 'VarDecl':
-        kind = 'v'
-      elif k == 'macro definition':
-        kind = 'd'
-      elif k == 'EnumDecl':
-        kind = 'e'
-      elif k == 'TypedefDecl' or k == 'StructDecl' or k == 'EnumConstantDecl':
-        kind = 't'
+        k = c['kind']
+        kind = ''
+        if k == 'FunctionDecl' or k == 'FunctionTemplate':
+            kind = 'f'
+        elif k == 'CXXMethod' or k == 'CXXConstructor':
+            kind = 'm'
+        elif k == 'VarDecl':
+            kind = 'v'
+        elif k == 'macro definition':
+            kind = 'd'
+        elif k == 'EnumDecl':
+            kind = 'e'
+        elif k == 'TypedefDecl' or k == 'StructDecl' or k == 'EnumConstantDecl':
+            kind = 't'
 
-      match = {'menu': " ".join([c['parent'], c['signature']]), 'word': c['completion'], 'kind': kind}
-      completions.append(match)
+    match = {'menu': " ".join([c['parent'], c['signature']]), 'word': c['completion'], 'kind': kind}
+    completions.append(match)
 
     return completions
+
 
 def send_completion_request():
     filename = vim.eval('s:file')
@@ -131,14 +134,15 @@ def send_completion_request():
             lines = [x for x in buffer]
             content = '\n'.join(lines[:line - 1] + [lines[line - 1] + prefix] + lines[line:])
 
-            cmd = ('--synchronous-completions -l %s:%d:%d --unsaved-file=%s:%d --json'
-                % (filename, line, column, filename, len(content)))
+            cmd = '--synchronous-completions -l %s:%d:%d --unsaved-file=%s:%d --json' % (
+                filename, line, column, filename, len(content)
+            )
             if len(prefix) > 0:
                 cmd += ' --code-complete-prefix %s' % prefix
 
             content = run_rc_command(cmd, content)
             logger.debug("Got completion: %s" % content)
-            if content == None:
+            if content is None:
                 return None
 
             return parse_completion_result(content)
@@ -621,6 +625,7 @@ class Sign(object):
             group on initialisation (e.g. gitgutter).
         """
         logger.debug("Defining gutter diagnostic signs")
+
         # Recursively search for background colours through group links.
         def get_bgcolour(group):
             logger.debug("Scanning highlight group %s for background colour" % group)
@@ -698,4 +703,3 @@ def error(msg):
 
 def message(msg):
     vim.command("""echom '%s'""" % msg)
-

--- a/plugin/vimrtags.py
+++ b/plugin/vimrtags.py
@@ -709,7 +709,7 @@ def invalid_buffer_message(filename):
 
 
 def error(msg):
-    message("""%s: see log file at" "%s" for more information""" % (msg, logfile))
+    message("""%s: see log file at" "%s" for more information""" % (msg, vim.eval('g:rtagsLog')))
 
 
 def message(msg):

--- a/plugin/vimrtags.py
+++ b/plugin/vimrtags.py
@@ -128,8 +128,9 @@ def parse_completion_result(data):
 
 
 def _completion_description(completion, fields):
+    fields += ['brief_comment']
     fields = [field for field in fields if completion[field] != completion['completion']]
-    fields = ['completion'] + fields + ['brief_comment']
+    fields = ['completion'] + fields
     return " -- ".join(filter(None, [completion[field] for field in fields]))
 
 

--- a/plugin/vimrtags.py
+++ b/plugin/vimrtags.py
@@ -129,6 +129,7 @@ def display_locations(errors, buffer):
     if len(errors) == 0:
         return
 
+    errors = sorted(errors, key=lambda e: e['type'])
     error_data = json.dumps(errors)
     max_height = int(get_rtags_variable('MaxSearchResultWindowHeight'))
     height = min(max_height, len(errors))

--- a/plugin/vimrtags.py
+++ b/plugin/vimrtags.py
@@ -237,10 +237,9 @@ class Buffer(object):
     def _clean_cache():
         """ Clean closed buffers
         """
-        logger.debug("Cleaning invalid buffers")
         for id_old in list(Buffer._cache.keys()):
             if not Buffer._cache[id_old]._vimbuffer.valid:
-                logger.debug("Cleaning invalid buffer %s" % id_old)
+                logger.debug("Cleaning invalid buffer: %s" % id_old)
                 del Buffer._cache[id_old]
         Buffer._cache_last_cleaned = time()
 

--- a/plugin/vimrtags.py
+++ b/plugin/vimrtags.py
@@ -47,7 +47,7 @@ def run_rc_command(arguments, content=None):
     if sys.version_info.major == 3 and sys.version_info.minor >= 5:
         r = subprocess.run(
             cmdline,
-            input=content and content.encode("utf-8"),
+            input=content and content.encode(encoding),
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE
         )
@@ -742,7 +742,7 @@ def invalid_buffer_message(filename):
 
 
 def error(msg):
-    message("""%s: see log file at" "%s" for more information""" % (msg, vim.eval('g:rtagsLog')))
+    message("""%s: see log file at "%s" for more information""" % (msg, vim.eval('g:rtagsLog')))
 
 
 def message(msg):

--- a/plugin/vimrtags.py
+++ b/plugin/vimrtags.py
@@ -200,7 +200,7 @@ class Buffer(object):
         # Periodically clean closed buffers
         if time() - Buffer._cache_last_cleaned > Buffer._CACHE_CLEAN_PERIOD:
             logger.debug("Cleaning invalid buffers")
-            for id_ in Buffer._cache.keys():
+            for id_ in list(Buffer._cache.keys()):
                 if not Buffer._cache[id_]._vimbuffer.valid:
                     logger.debug("Cleaning invalid buffer %s" % id_)
                     del Buffer._cache[id_]

--- a/plugin/vimrtags.py
+++ b/plugin/vimrtags.py
@@ -198,6 +198,17 @@ class Buffer(object):
             return buff
 
         # Periodically clean closed buffers
+        Buffer._clean_cache()
+
+        logger.debug("Wrapping new buffer: %s" % id_)
+        buff = Buffer(vim.buffers[id_])
+        Buffer._cache[id_] = buff
+        return buff
+
+    @staticmethod
+    def _clean_cache():
+        """ Periodically clean closed buffers
+        """
         if time() - Buffer._cache_last_cleaned > Buffer._CACHE_CLEAN_PERIOD:
             logger.debug("Cleaning invalid buffers")
             for id_old in list(Buffer._cache.keys()):
@@ -205,11 +216,6 @@ class Buffer(object):
                     logger.debug("Cleaning invalid buffer %s" % id_old)
                     del Buffer._cache[id_old]
             Buffer._cache_last_cleaned = time()
-
-        logger.debug("Wrapping new buffer: %s" % id_)
-        buff = Buffer(vim.buffers[id_])
-        Buffer._cache[id_] = buff
-        return buff
 
     @staticmethod
     def show_all_diagnostics():

--- a/plugin/vimrtags.py
+++ b/plugin/vimrtags.py
@@ -199,10 +199,10 @@ class Buffer(object):
         # Periodically clean closed buffers
         if time() - Buffer._cache_last_cleaned > Buffer._CACHE_CLEAN_PERIOD:
             logger.debug("Cleaning invalid buffers")
-            for id_ in list(Buffer._cache.keys()):
-                if not Buffer._cache[id_]._vimbuffer.valid:
-                    logger.debug("Cleaning invalid buffer %s" % id_)
-                    del Buffer._cache[id_]
+            for id_old in list(Buffer._cache.keys()):
+                if not Buffer._cache[id_old]._vimbuffer.valid:
+                    logger.debug("Cleaning invalid buffer %s" % id_old)
+                    del Buffer._cache[id_old]
             Buffer._cache_last_cleaned = time()
 
         logger.debug("Wrapping new buffer: %s" % id_)

--- a/plugin/vimrtags.py
+++ b/plugin/vimrtags.py
@@ -247,6 +247,10 @@ class Buffer(object):
         """ Get all diagnostics for all files and show in quickfix list.
         """
         # Get the diagnostics from rtags.
+        content = run_rc_command([
+            '--diagnose-all', '--current-file', vim.current.buffer.name,
+            '--synchronous-diagnostics', '--json'
+        ])
         content = run_rc_command(['--diagnose-all',  '--synchronous-diagnostics', '--json'])
         if content is None:
             return error('Failed to get diagnostics')

--- a/plugin/vimrtags.py
+++ b/plugin/vimrtags.py
@@ -636,7 +636,7 @@ class Diagnostic(object):
     def to_qlist_errors(diagnostics):
         num_diagnostics = len(diagnostics)
         # Sort diagnostics into display order. Errors at top, grouped by filename in line num order.
-        diagnostics = sorted(diagnostics, key=lambda d: (d.type, d.filename, d.line_num))
+        diagnostics = sorted(diagnostics, key=lambda d: (d.type, d._filename, d.line_num))
         # Convert Diagnostic objects into quickfix compatible dicts.
         diagnostics = [d._to_qlist_dict() for d in diagnostics]
         # Add error number to diagnostic (shows in list, maybe useful for navigation?).
@@ -651,9 +651,9 @@ class Diagnostic(object):
         return height, diagnostics
 
     def __init__(self, filename, line_num, char_num, type_, text):
-        self.filename = filename
+        self._filename = filename
         self.line_num = line_num
-        self.char_num = char_num
+        self._char_num = char_num
         self.type = type_
         self.text = text
 
@@ -661,8 +661,8 @@ class Diagnostic(object):
         error_type = "W" if self.type == "warning" else "E"
         text = self.text if self.type != "fixit" else self.text + " [FIXIT]"
         return {
-            'lnum': self.line_num, 'col': self.char_num, 'text': text,
-            'filename': self.filename, 'type': error_type
+            'lnum': self.line_num, 'col': self._char_num, 'text': text,
+            'filename': self._filename, 'type': error_type
         }
 
 
@@ -724,8 +724,8 @@ class Sign(object):
             sign_ids.add(int(sign_match.group(1)))
         return sign_ids
 
-    def __init__(self, id, line_num, name, buffer_num):
-        self.id = id
+    def __init__(self, id_, line_num, name, buffer_num):
+        self.id = id_
         self._vimbuffer_num = buffer_num
         if not Sign._is_signs_defined:
             Sign._define_signs()

--- a/plugin/vimrtags.py
+++ b/plugin/vimrtags.py
@@ -436,7 +436,7 @@ class Buffer(object):
         content = "\n".join([x for x in self._vimbuffer])
         result = run_rc_command([
             '--json', '--reindex', self._vimbuffer.name,
-            '--unsaved-file=%s:%d' % (self._vimbuffer.name, len(content))
+            '--unsaved-file', '%s:%d' % (self._vimbuffer.name, len(content))
         ], content)
         self._is_dirty = False
         logger.debug("Rtags responded to reindex request: %s" % result)

--- a/plugin/vimrtags.py
+++ b/plugin/vimrtags.py
@@ -360,7 +360,7 @@ class Buffer(object):
         # Not safe to apply fixits if file is not indexed, make extra sure it is.
         if (
             self._rtags_is_reindexing() or (
-                int(vim.eval("g:rtagsAutoDiagnostics")) and
+                int(get_rtags_variable("AutoDiagnostics")) and
                 self._last_diagnostics_time < self._project.last_updated_time()
             )
         ):

--- a/plugin/vimrtags.py
+++ b/plugin/vimrtags.py
@@ -257,7 +257,7 @@ class Buffer(object):
 
         if self._is_dirty:
             # `TextChange` autocmd also triggers just by switching buffers, so we have to be sure.
-            is_really_dirty = vim.eval('getbufvar(%d, "&mod")' % self._vimbuffer.number)
+            is_really_dirty = int(vim.eval('getbufvar(%d, "&mod")' % self._vimbuffer.number))
         else:
             is_really_dirty = False
 

--- a/tests/test_vimrtags.py
+++ b/tests/test_vimrtags.py
@@ -1,0 +1,1246 @@
+import json
+import logging
+import sys
+from unittest import TestCase
+from unittest.mock import Mock, MagicMock, patch, call
+
+from nose.tools import set_trace
+
+# Create a mocked vim in the environment.
+vim = MagicMock()
+sys.modules["vim"] = vim
+
+with patch.object(logging, "FileHandler"):
+    from plugin import vimrtags
+
+vim.reset_mock()
+
+
+class VimRtagsTest(TestCase):
+    def setUp(self):
+        vim.reset_mock()
+
+
+@patch("plugin.vimrtags.logging", autospec=True)
+@patch("plugin.vimrtags.logger", autospec=True)
+class Test_configure_logger(VimRtagsTest):
+
+    def test_logs_to_user_defined_file(self, logger, logging):
+        vimrtags.configure_logger()
+
+        vim.eval.assert_called_once_with('g:rtagsLog')
+        logging.FileHandler.assert_called_once_with(vim.eval.return_value)
+        logger.addHandler.assert_called_once_with(logging.FileHandler.return_value)
+
+
+class Test_parse_completion_result(VimRtagsTest):
+
+    def test(self):
+        completions = []
+        for kind in (
+            'FunctionDecl', 'FunctionTemplate', 'CXXMethod', 'CXXConstructor', 'VarDecl',
+            'macro definition', 'EnumDecl', 'TypedefDecl', 'StructDecl', 'EnumConstantDecl',
+            'ClassDecl', 'FieldDecl', 'Unknown'
+        ):
+            completions += self._completion(kind)
+
+        completions = {'completions': completions}
+
+        parsed = vimrtags.parse_completion_result(json.dumps(completions))
+
+        self.assertListEqual(
+            parsed, [
+                self._with_parent_sig('f'), self._simple('f'), self._simple('f'),
+                self._with_parent_sig('f'), self._simple('f'), self._simple('f'),
+                self._with_parent_sig('m'), self._simple('m'), self._simple('m'),
+                self._with_parent_sig('m'), self._simple('m'), self._simple('m'),
+                self._with_parent_sig('v'), self._simple('v'), self._simple('v'),
+                self._with_sig('d'), self._simple('d'), self._simple('d'),
+                self._with_parent('e'), self._simple('e'), self._simple('e'),
+                self._with_parent('t'), self._simple('t'), self._simple('t'),
+                self._with_parent('t'), self._simple('t'), self._simple('t'),
+                self._with_parent('t'), self._simple('t'), self._simple('t'),
+                self._with_parent('t'), self._simple('t'), self._simple('t'),
+                self._with_parent('t'), self._simple('t'), self._simple('t'),
+                self._with_comment(''), self._simple(''), self._simple('')
+            ]
+        )
+
+    def _completion(self, kind):
+        return [{
+            'kind': kind,
+            'completion': 'mock completion',
+            'parent': 'mock parent',
+            'signature': 'mock signature',
+            'brief_comment': 'mock comment',
+        }, {
+            'kind': kind,
+            'completion': 'mock completion',
+            'parent': 'mock completion',
+            'signature': 'mock completion',
+            'brief_comment': 'mock completion',
+        }, {
+            'kind': kind,
+            'completion': 'mock completion',
+            'parent': '',
+            'signature': '',
+            'brief_comment': '',
+        }]
+
+    def _with_parent_sig(self, kind):
+        return {
+            'menu': "mock completion -- mock parent -- mock signature -- mock comment",
+            'word': "mock completion", 'kind': kind
+        }
+
+    def _with_sig(self, kind):
+        return {
+            'menu': "mock completion -- mock signature -- mock comment", 'word': "mock completion",
+            'kind': kind
+        }
+
+    def _with_parent(self, kind):
+        return {
+            'menu': "mock completion -- mock parent -- mock comment", 'word': "mock completion",
+            'kind': kind
+        }
+
+    def _with_comment(self, kind):
+        return {
+            'menu': "mock completion -- mock comment", 'word': "mock completion", 'kind': kind
+        }
+
+    def _simple(self, kind):
+        return {
+            'menu': "mock completion", 'word': "mock completion", 'kind': kind
+        }
+
+
+class Test_Buffer_find(VimRtagsTest):
+    def setUp(self):
+        super(Test_Buffer_find, self).setUp()
+        first = Mock()
+        second = Mock(number=9)
+        third = Mock()
+        first.name = "first buf"
+        second.name = "second buf"
+        third.name = "third buf"
+        vim.buffers = [first, second, third]
+
+    def test_not_found(self):
+        buffer = vimrtags.Buffer.find("wont find")
+        self.assertIsNone(buffer)
+
+    @patch("plugin.vimrtags.Buffer.get")
+    def test_found(self, get):
+        buffer = vimrtags.Buffer.find("second buf")
+        get.assert_called_once_with(9)
+        self.assertIs(buffer, get.return_value)
+
+
+@patch("plugin.vimrtags.logger", Mock(spec=logging.Logger))
+@patch("plugin.vimrtags.Buffer._cache", {})
+class Test_Buffer_get(VimRtagsTest):
+    def test_found(self):
+        cached_buffer = Mock()
+        vimrtags.Buffer._cache = {3: cached_buffer}
+        buffer = vimrtags.Buffer.get(3)
+        self.assertIs(buffer, cached_buffer)
+
+    @patch("plugin.vimrtags.Project", MagicMock())
+    @patch("plugin.vimrtags.Buffer._clean_cache")
+    def test_not_found(self, _clean_cache):
+        vimbuffer = Mock()
+        vim.buffers.append(vimbuffer)
+        other_buffer = Mock()
+        vimrtags.Buffer._cache = {4: other_buffer}
+
+        buffer = vimrtags.Buffer.get(3)
+        buffer_again = vimrtags.Buffer.get(3)
+
+        _clean_cache.assert_called_once_with()
+        self.assertIsInstance(buffer, vimrtags.Buffer)
+        self.assertIs(buffer._vimbuffer, vimbuffer)
+        self.assertDictEqual(vimrtags.Buffer._cache, {3: buffer, 4: other_buffer})
+        self.assertIs(buffer, buffer_again)
+
+
+@patch("plugin.vimrtags.logger", Mock(spec=logging.Logger))
+@patch("plugin.vimrtags.time", autospec=True)
+@patch("plugin.vimrtags.Buffer._cache", {})
+@patch("plugin.vimrtags.Buffer._cache_last_cleaned", 6)
+@patch("plugin.vimrtags.Buffer._CACHE_CLEAN_PERIOD", 4)
+class Test_Buffer__clean_cache(VimRtagsTest):
+    def prepare(self):
+        self.buffer = Mock(_vimbuffer=Mock(valid=False))
+        vimrtags.Buffer._cache = {3: self.buffer}
+
+    def test_throttled(self, time):
+        self.prepare()
+        time.return_value = 10
+        vimrtags.Buffer._clean_cache()
+        self.assertIs(vimrtags.Buffer._cache[3], self.buffer)
+
+    def test_removes(self, time):
+        self.prepare()
+        time.return_value = 11
+        vimrtags.Buffer._clean_cache()
+        self.assertDictEqual(vimrtags.Buffer._cache, {})
+
+
+@patch("plugin.vimrtags.run_rc_command", autospec=True)
+class Test_Buffer_show_all_diagnostics(VimRtagsTest):
+
+    @patch("plugin.vimrtags.error", autospec=True)
+    def test_rc_fails(self, error, run_rc_command):
+        run_rc_command.return_value = None
+        vimrtags.Buffer.show_all_diagnostics()
+        error.assert_called()
+        self.assertFalse(vim.command.called)
+
+    @patch("plugin.vimrtags.message", autospec=True)
+    def test_no_diagnostics(self, message, run_rc_command):
+        run_rc_command.return_value = '{"checkStyle": {}}'
+        vimrtags.Buffer.show_all_diagnostics()
+        message.assert_called()
+        self.assertFalse(vim.command.called)
+
+    def prepare(self, get_rtags_variable, Diagnostic, run_rc_command):
+        run_rc_command.return_value = (
+            '{"checkStyle": {"file 1": ["error 1", "error 2"], "file 2": ["error 3"]}}'
+        )
+        Diagnostic.from_rtags_errors.side_effect = [["diag 1", "diag 2"], ["diag 3"]]
+        Diagnostic.to_qlist_errors.return_value = (123, "lines")
+        vim.current.window.number = 7
+
+    @patch("plugin.vimrtags.Buffer._DIAGNOSTICS_ALL_LIST_TITLE", "list title")
+    @patch("plugin.vimrtags.Diagnostic", autospec=True)
+    @patch("plugin.vimrtags.get_rtags_variable", autospec=True)
+    def test_use_loclist(self, get_rtags_variable, Diagnostic, run_rc_command):
+        self.prepare(get_rtags_variable, Diagnostic, run_rc_command)
+
+        get_rtags_variable.return_value = 1
+        vimrtags.Buffer.show_all_diagnostics()
+
+        self.assert_diagnostics_constructed(Diagnostic)
+        vim.eval.assert_called_once_with(
+            'setloclist(7, [], " ", {"items": lines, "title": "list title"})'
+        )
+        vim.command.assert_called_once_with("lopen 123")
+
+    @patch("plugin.vimrtags.Buffer._DIAGNOSTICS_ALL_LIST_TITLE", "list title")
+    @patch("plugin.vimrtags.Diagnostic", autospec=True)
+    @patch("plugin.vimrtags.get_rtags_variable", autospec=True)
+    def test_use_qlist(self, get_rtags_variable, Diagnostic, run_rc_command):
+        self.prepare(get_rtags_variable, Diagnostic, run_rc_command)
+
+        get_rtags_variable.return_value = 0
+        vimrtags.Buffer.show_all_diagnostics()
+
+        self.assert_diagnostics_constructed(Diagnostic)
+        vim.eval.assert_called_once_with(
+            'setqflist([], " ", {"items": lines, "title": "list title"})'
+        )
+        vim.command.assert_called_once_with("copen 123")
+
+    def assert_diagnostics_constructed(self, Diagnostic):
+        self.assertListEqual(
+            Diagnostic.from_rtags_errors.call_args_list, [
+                call("file 1", ["error 1", "error 2"]),
+                call("file 2", ["error 3"])
+            ]
+        )
+        Diagnostic.to_qlist_errors.assert_called_once_with(["diag 1", "diag 2", "diag 3"])
+
+
+@patch("plugin.vimrtags.Project", autospec=True)
+class Test_Buffer_init(VimRtagsTest):
+    def test(self, Project):
+        vimbuffer = Mock()
+        vimbuffer.name = "mock buffer"
+
+        buffer = vimrtags.Buffer(vimbuffer)
+
+        self.assertIs(buffer._vimbuffer, vimbuffer)
+        Project.get.assert_called_once_with("mock buffer")
+        self.assertIs(buffer._project, Project.get.return_value)
+
+
+class MockVimBuffer(list):
+    def __init__(self):
+        super(MockVimBuffer, self).__init__()
+        self.name = "mock buffer"
+        self.number = 7
+
+
+class BufferInstanceTest(VimRtagsTest):
+    def setUp(self):
+        super(BufferInstanceTest, self).setUp()
+        self.project = Mock(spec=vimrtags.Project)
+        self.vimbuffer = MockVimBuffer()
+
+        with patch("plugin.vimrtags.Project.get", Mock(return_value=self.project)):
+            self.buffer = vimrtags.Buffer(self.vimbuffer)
+
+
+class Test_Buffer_on_write(BufferInstanceTest):
+    def test(self):
+        self.buffer._is_dirty = True
+
+        self.buffer.on_write()
+
+        self.assertFalse(self.buffer._is_dirty)
+
+
+class Test_Buffer_on_edit(BufferInstanceTest):
+    def test_no_project(self):
+        self.buffer._project = None
+
+        self.buffer.on_edit()
+
+        self.assertFalse(self.buffer._is_dirty)
+
+    def test_has_project(self):
+        self.buffer.on_edit()
+
+        self.assertTrue(self.buffer._is_dirty)
+
+
+@patch("plugin.vimrtags.logger", Mock(spec=logging.Logger))
+@patch("plugin.vimrtags.Buffer._is_really_dirty", autospec=True)
+@patch("plugin.vimrtags.Buffer._rtags_dirty_reindex", autospec=True)
+@patch("plugin.vimrtags.Buffer._update_diagnostics", autospec=True)
+class Test_Buffer_on_idle(BufferInstanceTest):
+    def test_no_project(self, _update_diagnostics, _rtags_dirty_reindex, _is_really_dirty):
+        self.buffer._project = None
+
+        self.buffer.on_idle()
+
+        self.assertFalse(_is_really_dirty.called)
+        self.assertFalse(_update_diagnostics.called)
+        self.assertFalse(_rtags_dirty_reindex.called)
+
+    def test_nothing_to_do(self, _update_diagnostics, _rtags_dirty_reindex, _is_really_dirty):
+        _is_really_dirty.return_value = False
+        self.buffer._last_diagnostics_time = 1
+        self.project.last_updated_time.return_value = 1
+
+        self.buffer.on_idle()
+
+        self.assertFalse(_update_diagnostics.called)
+        self.assertFalse(_rtags_dirty_reindex.called)
+
+    @patch("plugin.vimrtags.time", autospec=True)
+    def test_reindex(self, time, _update_diagnostics, _rtags_dirty_reindex, _is_really_dirty):
+        _is_really_dirty.return_value = True
+
+        self.buffer.on_idle()
+
+        self.assertIs(self.buffer._last_diagnostics_time, time.return_value)
+        _rtags_dirty_reindex.assert_called_once_with(self.buffer)
+        self.assertFalse(_update_diagnostics.called)
+
+    def test_update_diagnostics(self, _update_diagnostics, _rtags_dirty_reindex, _is_really_dirty):
+        _is_really_dirty.return_value = False
+        self.buffer._last_diagnostics_time = 1
+        self.project.last_updated_time.return_value = 2
+
+        self.buffer.on_idle()
+
+        self.assertFalse(_rtags_dirty_reindex.called)
+        _update_diagnostics.assert_called_once_with(self.buffer)
+
+
+@patch("plugin.vimrtags.Buffer._is_really_dirty", autospec=True)
+@patch("plugin.vimrtags.Buffer._update_diagnostics", autospec=True)
+class Test_Buffer_on_poll(BufferInstanceTest):
+    def test_no_project(self, _update_diagnostics, _is_really_dirty):
+        self.buffer._project = None
+
+        self.buffer.on_poll()
+
+        self.assertFalse(_is_really_dirty.called)
+        self.assertFalse(_update_diagnostics.called)
+
+    def test_is_dirty(self, _update_diagnostics, _is_really_dirty):
+        _is_really_dirty.return_value = True
+        self.buffer._last_diagnostics_time = 1
+        self.project.last_updated_time.return_value = 2
+
+        self.buffer.on_poll()
+
+        self.assertFalse(_update_diagnostics.called)
+
+    def test_too_soon(self, _update_diagnostics, _is_really_dirty):
+        _is_really_dirty.return_value = False
+        self.buffer._last_diagnostics_time = 2
+        self.project.last_updated_time.return_value = 2
+
+        self.buffer.on_poll()
+
+        self.assertFalse(_update_diagnostics.called)
+
+    @patch("plugin.vimrtags.logger", Mock(spec=logging.Logger))
+    def test_update(self, _update_diagnostics, _is_really_dirty):
+        _is_really_dirty.return_value = False
+        self.buffer._last_diagnostics_time = 1
+        self.project.last_updated_time.return_value = 2
+
+        self.buffer.on_poll()
+
+        _update_diagnostics.assert_called_once_with(self.buffer)
+
+
+@patch("plugin.vimrtags.print", autospec=True)
+class Test_Buffer_on_cursor_moved(BufferInstanceTest):
+    def test_no_project(self, print_):
+        self.buffer._project = None
+
+        self.buffer.on_cursor_moved()
+
+        self.assertFalse(print_.called)
+
+    def test_line_num_not_changed(self, print_):
+        self.buffer._line_num_last = 2
+        vim.current.window.cursor = (2, 123)
+
+        self.buffer.on_cursor_moved()
+
+        self.assertFalse(print_.called)
+
+    def test_no_diagnostic_now_or_before(self, print_):
+        self.buffer._line_num_last = 1
+        vim.current.window.cursor = (2, 123)
+        self.buffer._diagnostics = {3: Mock(text="mock diagnostic")}
+
+        self.buffer.on_cursor_moved()
+
+        self.assertFalse(print_.called)
+
+    def test_has_diagnostic(self, print_):
+        self.buffer._line_num_last = 1
+        vim.current.window.cursor = (3, 123)
+        self.buffer._diagnostics = {3: Mock(text="mock diagnostic")}
+
+        self.buffer.on_cursor_moved()
+
+        print_.assert_called_once_with("mock diagnostic")
+        self.assertTrue(self.buffer._is_line_diagnostic_shown)
+
+    def test_no_diagnostic_now_but_had_one_before(self, print_):
+        self.buffer._line_num_last = 1
+        vim.current.window.cursor = (2, 123)
+        self.buffer._diagnostics = {3: Mock(text="mock diagnostic")}
+        self.buffer._is_line_diagnostic_shown = True
+
+        self.buffer.on_cursor_moved()
+
+        print_.assert_called_once_with("")
+        self.assertFalse(self.buffer._is_line_diagnostic_shown)
+
+
+@patch("plugin.vimrtags.Buffer._update_diagnostics", autospec=True)
+class Test_Buffer_show_diagnostics_list(BufferInstanceTest):
+
+    @patch("plugin.vimrtags.invalid_buffer_message", autospec=True)
+    def test_no_project(self, invalid_buffer_message, _update_diagnostics):
+        self.buffer._project = None
+
+        self.buffer.show_diagnostics_list()
+
+        self.assertFalse(_update_diagnostics.called)
+        invalid_buffer_message.assert_called_once_with("mock buffer")
+
+    @patch("plugin.vimrtags.message", autospec=True)
+    def test_has_diagnostics(self, message, _update_diagnostics):
+
+        def set_diagnostics(*args, **kwargs):
+            self.buffer._diagnostics = "something"
+
+        _update_diagnostics.side_effect = set_diagnostics
+
+        self.buffer.show_diagnostics_list()
+
+        _update_diagnostics.assert_called_once_with(self.buffer, open_loclist=True)
+        self.assertFalse(message.called)
+
+    @patch("plugin.vimrtags.message", autospec=True)
+    def test_no_diagnostics(self, message, _update_diagnostics):
+
+        def set_diagnostics(*args, **kwargs):
+            self.buffer._diagnostics = None
+
+        _update_diagnostics.side_effect = set_diagnostics
+
+        self.buffer.show_diagnostics_list()
+
+        _update_diagnostics.assert_called_once_with(self.buffer, open_loclist=True)
+        self.assertTrue(message.called)
+
+
+@patch("plugin.vimrtags.logger", Mock(spec=logging.Logger))
+@patch("plugin.vimrtags.get_rtags_variable", autospec=True)
+@patch("plugin.vimrtags.run_rc_command", autospec=True)
+@patch("plugin.vimrtags.Buffer._rtags_is_reindexing", autospec=True)
+class Test_Buffer_apply_fixits(BufferInstanceTest):
+
+    def prepare(self, _rtags_is_reindexing, get_rtags_variable):
+        _rtags_is_reindexing.return_value = False
+        get_rtags_variable.side_effect = ["1", "20"]
+        self.buffer._last_diagnostics_time = 1
+        self.buffer._project.last_updated_time.return_value = 1
+
+    @patch("plugin.vimrtags.invalid_buffer_message", autospec=True)
+    def test_no_project(
+        self, invalid_buffer_message, _rtags_is_reindexing, run_rc_command, get_rtags_variable
+    ):
+        self.prepare(_rtags_is_reindexing, get_rtags_variable)
+        self.buffer._project = None
+
+        self.buffer.apply_fixits()
+
+        invalid_buffer_message.assert_called_once_with("mock buffer")
+        self.assertFalse(_rtags_is_reindexing.called)
+        self.assertFalse(run_rc_command.called)
+        self.assertFalse(vim.eval.called)
+        self.assertFalse(vim.command.called)
+
+    @patch("plugin.vimrtags.message", autospec=True)
+    def test_is_reindexing(
+        self, message, _rtags_is_reindexing, run_rc_command, get_rtags_variable
+    ):
+        self.prepare(_rtags_is_reindexing, get_rtags_variable)
+        _rtags_is_reindexing.return_value = True
+
+        self.buffer.apply_fixits()
+
+        self.assertTrue(message.called)
+        self.assertFalse(run_rc_command.called)
+        self.assertFalse(vim.command.called)
+
+    @patch("plugin.vimrtags.message", autospec=True)
+    def test_has_changes_to_project(
+        self, message, _rtags_is_reindexing, run_rc_command, get_rtags_variable
+    ):
+        self.prepare(_rtags_is_reindexing, get_rtags_variable)
+        self.buffer._project.last_updated_time.return_value = 2
+
+        self.buffer.apply_fixits()
+
+        self.assertTrue(message.called)
+        self.assertFalse(run_rc_command.called)
+        self.assertFalse(vim.command.called)
+
+    @patch("plugin.vimrtags.error", autospec=True)
+    def test_rc_fails(
+        self, error, _rtags_is_reindexing, run_rc_command, get_rtags_variable
+    ):
+        self.prepare(_rtags_is_reindexing, get_rtags_variable)
+        run_rc_command.return_value = None
+
+        self.buffer.apply_fixits()
+
+        run_rc_command.assert_called_once_with(['--fixits', 'mock buffer'])
+        self.assertTrue(error.called)
+        self.assertFalse(vim.command.called)
+
+    @patch("plugin.vimrtags.message", autospec=True)
+    def test_no_fixits_found(
+        self, message, _rtags_is_reindexing, run_rc_command, get_rtags_variable
+    ):
+        self.prepare(_rtags_is_reindexing, get_rtags_variable)
+        run_rc_command.return_value = "   "
+        vim.current.window.number = 5
+
+        self.buffer.apply_fixits()
+
+        run_rc_command.assert_called_once_with(['--fixits', 'mock buffer'])
+        self.assertTrue(message.called)
+        self.assertFalse(vim.command.called)
+
+    def prepare_buffer(self, run_rc_command, dumps):
+        fixit_txt = """
+some junk
+1:2 3 first
+10:11 12 second
+"""
+        run_rc_command.return_value = fixit_txt
+        vim.current.window.number = 5
+        dumps.return_value = "some json"
+        self.vimbuffer += [
+             "some mock text to be fixed",
+             "not modified",
+             "not modified",
+             "not modified",
+             "not modified",
+             "not modified",
+             "not modified",
+             "not modified",
+             "not modified",
+             "some other mock text to be fixed",
+             "not modified",
+             "not modified"
+        ]
+
+    def assert_buffer_and_loclist(self, dumps, message):
+        self.assertListEqual(
+            self.vimbuffer, [
+             "sfirst mock text to be fixed",
+             "not modified",
+             "not modified",
+             "not modified",
+             "not modified",
+             "not modified",
+             "not modified",
+             "not modified",
+             "not modified",
+             "some othersecondo be fixed",
+             "not modified",
+             "not modified"
+        ])
+
+        dumps.assert_called_once_with([
+            {'lnum': 1, 'col': 2, 'text': "first", 'filename': "mock buffer"},
+            {'lnum': 10, 'col': 11, 'text': "second", 'filename': "mock buffer"}
+        ])
+        vim.eval.assert_called_once_with(
+            'setloclist(5, [], " ", {"items": some json, "title": "list title"})'
+        )
+        self.assertTrue(message.called)
+
+    @patch("plugin.vimrtags.Buffer._FIXITS_LIST_TITLE", "list title")
+    @patch("plugin.vimrtags.message", autospec=True)
+    @patch("plugin.vimrtags.json.dumps", autospec=True)
+    def test_fixits_found_fits_in_max_height(
+        self, dumps, message, _rtags_is_reindexing, run_rc_command, get_rtags_variable
+    ):
+        self.prepare(_rtags_is_reindexing, get_rtags_variable)
+        self.prepare_buffer(run_rc_command, dumps)
+
+        self.buffer.apply_fixits()
+
+        self.assert_buffer_and_loclist(dumps, message)
+        vim.command.assert_called_once_with('lopen 2')
+
+    @patch("plugin.vimrtags.Buffer._FIXITS_LIST_TITLE", "list title")
+    @patch("plugin.vimrtags.message", autospec=True)
+    @patch("plugin.vimrtags.json.dumps", autospec=True)
+    def test_fixits_found_doesnt_fit_in_max_height(
+        self, dumps, message, _rtags_is_reindexing, run_rc_command, get_rtags_variable
+    ):
+        self.prepare(_rtags_is_reindexing, get_rtags_variable)
+        self.prepare_buffer(run_rc_command, dumps)
+        get_rtags_variable.side_effect = ["1", "1"]
+
+        self.buffer.apply_fixits()
+
+        self.assert_buffer_and_loclist(dumps, message)
+        vim.command.assert_called_once_with('lopen 1')
+
+    @patch("plugin.vimrtags.Buffer._FIXITS_LIST_TITLE", "list title")
+    @patch("plugin.vimrtags.message", autospec=True)
+    @patch("plugin.vimrtags.json.dumps", autospec=True)
+    def test_fixits_found_when_auto_diagnostics_disabled(
+        self, dumps, message, _rtags_is_reindexing, run_rc_command, get_rtags_variable
+    ):
+        self.prepare(_rtags_is_reindexing, get_rtags_variable)
+        self.prepare_buffer(run_rc_command, dumps)
+        get_rtags_variable.side_effect = ["0", "20"]
+        self.buffer._project.last_updated_time.return_value = 2
+
+        self.buffer.apply_fixits()
+
+        self.assert_buffer_and_loclist(dumps, message)
+        vim.command.assert_called_once_with('lopen 2')
+
+
+class Test_Buffer__is_really_dirty(BufferInstanceTest):
+    def test_not_dirty(self):
+        self.buffer._is_dirty = False
+
+        is_dirty = self.buffer._is_really_dirty()
+
+        self.assertFalse(is_dirty)
+        self.assertFalse(vim.eval.called)
+
+    def test_is_dirty_but_not_really(self):
+        self.buffer._is_dirty = True
+        vim.eval.return_value = "0"
+
+        is_dirty = self.buffer._is_really_dirty()
+
+        vim.eval.assert_called_once_with('getbufvar(7, "&mod")')
+        self.assertFalse(is_dirty)
+
+    def test_is_dirty_really(self):
+        self.buffer._is_dirty = True
+        vim.eval.return_value = "1"
+
+        is_dirty = self.buffer._is_really_dirty()
+
+        vim.eval.assert_called_once_with('getbufvar(7, "&mod")')
+        self.assertTrue(is_dirty)
+
+
+@patch("plugin.vimrtags.logger", Mock(spec=logging.Logger))
+@patch("plugin.vimrtags.run_rc_command", autospec=True)
+class Test_Buffer__rtags_dirty_reindex(BufferInstanceTest):
+    def test(self, run_rc_command):
+        self.vimbuffer += ["ab", "cd"]
+        self.buffer._is_dirty = True
+
+        self.buffer._rtags_dirty_reindex()
+
+        run_rc_command.assert_called_once_with([
+            '--json', '--reindex', "mock buffer", '--unsaved-file', 'mock buffer:5'
+        ], "ab\ncd")
+        self.assertFalse(self.buffer._is_dirty)
+
+
+@patch("plugin.vimrtags.run_rc_command", autospec=True)
+class Test_Buffer__rtags_is_reindexing(BufferInstanceTest):
+
+    @patch("plugin.vimrtags.error", autospec=True)
+    def test_rc_fails(self, error, run_rc_command):
+        run_rc_command.return_value = None
+
+        is_reindexing = self.buffer._rtags_is_reindexing()
+
+        self.assertTrue(error.called)
+        self.assertIs(is_reindexing, error.return_value)
+
+    def test_not_reindexing(self, run_rc_command):
+        run_rc_command.return_value = "something"
+
+        is_reindexing = self.buffer._rtags_is_reindexing()
+
+        self.assertFalse(is_reindexing)
+
+    def test_is_reindexing(self, run_rc_command):
+        run_rc_command.return_value = "something mock buffer something"
+
+        is_reindexing = self.buffer._rtags_is_reindexing()
+
+        self.assertTrue(is_reindexing)
+
+
+@patch("plugin.vimrtags.logger", Mock(spec=logging.Logger))
+@patch("plugin.vimrtags.time", autospec=True)
+@patch("plugin.vimrtags.run_rc_command", autospec=True)
+@patch("plugin.vimrtags.Diagnostic", autospec=True)
+@patch("plugin.vimrtags.Buffer._update_loclist", autospec=True)
+@patch("plugin.vimrtags.Buffer._place_signs", autospec=True)
+@patch("plugin.vimrtags.Buffer.on_cursor_moved", autospec=True)
+class Test_Buffer__update_diagnostics(BufferInstanceTest):
+
+    @patch("plugin.vimrtags.error", autospec=True)
+    def test_rc_failed(
+        self, error, on_cursor_moved, _place_signs, _update_loclist, Diagnostic, run_rc_command,
+        time
+    ):
+        run_rc_command.return_value = None
+
+        self.buffer._update_diagnostics()
+
+        self.assertTrue(error.called)
+        self.assertFalse(_update_loclist.called)
+        self.assertFalse(_place_signs.called)
+
+    def test_success(
+        self, on_cursor_moved, _place_signs, _update_loclist, Diagnostic, run_rc_command, time
+    ):
+        # setup
+
+        self.buffer._diagnostics = "replace me"
+        self.buffer._line_num_last = "replace me"
+        open_loclist = Mock()
+
+        run_rc_command.return_value = '{"checkStyle": {"mock buffer": ["diag 1", "diag 2"]}}'
+
+        diag1 = Mock(line_num=3)
+        diag2 = Mock(line_num=12)
+        Diagnostic.from_rtags_errors.return_value = [diag1, diag2]
+
+        on_cursor_moved.side_effect = (
+            lambda *a, **k: self.assertEqual(self.buffer._line_num_last, -1)
+        )
+
+        # action
+
+        self.buffer._update_diagnostics(open_loclist=open_loclist)
+
+        # confirm
+
+        run_rc_command.assert_called_once_with([
+            '--diagnose', "mock buffer", '--synchronous-diagnostics', '--json'
+        ])
+        Diagnostic.from_rtags_errors.assert_called_once_with("mock buffer", ["diag 1", "diag 2"])
+
+        self.assertDictEqual(self.buffer._diagnostics, {3: diag1, 12: diag2})
+
+        _update_loclist.assert_called_once_with(self.buffer, open_loclist)
+        _place_signs.assert_called_once_with(self.buffer)
+        on_cursor_moved.assert_called_once_with(self.buffer)
+
+
+@patch("plugin.vimrtags.logger", Mock(spec=logging.Logger))
+@patch("plugin.vimrtags.Buffer._DIAGNOSTICS_LIST_TITLE", "list title")
+@patch("plugin.vimrtags.Diagnostic", autospec=True)
+class Test_Buffer__update_loclist(BufferInstanceTest):
+    def prepare(self, Diagnostic):
+        vim.current.window.number = 6
+        vim.current.window.buffer.number = 7
+        vim.eval.return_value = {'title': "list title"}
+        Diagnostic.to_qlist_errors.return_value = (3, "some json")
+
+    def test_not_current_window(self, Diagnostic):
+        self.prepare(Diagnostic)
+        vim.current.window.buffer.number = 123
+
+        self.buffer._update_loclist(False)
+
+        self.assertFalse(Diagnostic.to_qlist_errors.called)
+        self.assertFalse(vim.eval.called)
+        self.assertFalse(vim.command.called)
+
+    def test_not_force_not_already_open(self, Diagnostic):
+        self.prepare(Diagnostic)
+        vim.eval.return_value = {'title': "some other loclist"}
+
+        self.buffer._update_loclist(False)
+
+        vim.eval.assert_called_once_with('getloclist(6, {"title": 0})')
+        self.assertFalse(Diagnostic.to_qlist_errors.called)
+        self.assertFalse(vim.command.called)
+
+    def test_not_force_and_already_open(self, Diagnostic):
+        self.prepare(Diagnostic)
+
+        self.buffer._update_loclist(False)
+
+        self.assertListEqual(
+            vim.method_calls, [
+                call.eval('getloclist(6, {"title": 0})'),
+                call.eval('setloclist(6, [], "r", {"items": some json, "title": "list title"})')
+            ]
+        )
+
+    def test_force_and_already_open_no_results(self, Diagnostic):
+        self.prepare(Diagnostic)
+        Diagnostic.to_qlist_errors.return_value = (0, "some json")
+
+        self.buffer._update_loclist(True)
+
+        self.assertListEqual(
+            vim.method_calls, [
+                call.eval('getloclist(6, {"title": 0})'),
+                call.eval('setloclist(6, [], "r", {"items": some json, "title": "list title"})')
+            ]
+        )
+
+    def test_force_and_already_open_has_results(self, Diagnostic):
+        self.prepare(Diagnostic)
+
+        self.buffer._update_loclist(True)
+
+        self.assertListEqual(
+            vim.method_calls, [
+                call.eval('getloclist(6, {"title": 0})'),
+                call.eval('setloclist(6, [], "r", {"items": some json, "title": "list title"})'),
+                call.command('lopen 3')
+            ]
+        )
+
+    def test_force_not_already_open_has_results(self, Diagnostic):
+        self.prepare(Diagnostic)
+        vim.eval.return_value = {'title': "some other loclist"}
+
+        self.buffer._update_loclist(True)
+
+        self.assertListEqual(
+            vim.method_calls, [
+                call.eval('getloclist(6, {"title": 0})'),
+                call.eval('setloclist(6, [], " ", {"items": some json, "title": "list title"})'),
+                call.command('lopen 3')
+            ]
+        )
+
+
+@patch("plugin.vimrtags.logger", Mock(spec=logging.Logger))
+@patch("plugin.vimrtags.Sign", autospec=True)
+@patch("plugin.vimrtags.Buffer._reset_signs")
+@patch("plugin.vimrtags.Buffer._place_sign")
+class Test_Buffer__place_signs(BufferInstanceTest):
+
+    def test(self, _place_sign, _reset_signs, Sign):
+        self.buffer._diagnostics = {
+            3: Mock(spec=vimrtags.Diagnostic, line_num=4, type="a"),
+            56: Mock(spec=vimrtags.Diagnostic, line_num=65, type="b")
+        }
+        calls = MagicMock()
+        calls.attach_mock(_reset_signs, "reset")
+        calls.attach_mock(_place_sign, "place")
+
+        self.buffer._place_signs()
+
+        Sign.used_ids.assert_called_once_with(7)
+        self.assertListEqual(
+            calls.method_calls, [
+                call.reset(),
+                call.place(4, "a", Sign.used_ids.return_value),
+                call.place(65, "b", Sign.used_ids.return_value)
+            ]
+        )
+
+
+@patch("plugin.vimrtags.Sign", autospec=True)
+class Test_Buffer__place_sign(BufferInstanceTest):
+    def test(self, Sign):
+        Sign.START_ID = 100
+        Sign.side_effect = lambda id_, *a: Mock(id=id_)
+        used_ids = set([50, 102])
+
+        self.buffer._place_sign(123, "name 1", used_ids)
+        self.buffer._place_sign(456, "name 2", used_ids)
+        self.buffer._place_sign(789, "name 3", used_ids)
+
+        self.assertListEqual(
+            Sign.call_args_list, [
+                call(101, 123, "name 1", 7),
+                call(103, 456, "name 2", 7),
+                call(104, 789, "name 3", 7)
+            ]
+        )
+        self.assertEqual(len(self.buffer._signs), 3)
+        self.assertEqual(self.buffer._signs[0].id, 101)
+        self.assertEqual(self.buffer._signs[1].id, 103)
+        self.assertEqual(self.buffer._signs[2].id, 104)
+
+
+class Test_Buffer__reset_signs(BufferInstanceTest):
+    def test(self):
+        sign1 = Mock(spec=vimrtags.Sign)
+        sign2 = Mock(spec=vimrtags.Sign)
+        self.buffer._signs = [sign1, sign2]
+
+        self.buffer._reset_signs()
+
+        sign1.unplace.assert_called_once_with()
+        sign2.unplace.assert_called_once_with()
+        self.assertListEqual(self.buffer._signs, [])
+
+
+@patch("plugin.vimrtags.logger", Mock(spec=logging.Logger))
+@patch("plugin.vimrtags.run_rc_command", autospec=True)
+class Test_Project_get(VimRtagsTest):
+
+    def test_no_filename(self, run_rc_command):
+        project = vimrtags.Project.get("")
+
+        self.assertFalse(run_rc_command.called)
+        self.assertIsNone(project)
+
+    def test_rc_fails(self, run_rc_command):
+        run_rc_command.return_value = None
+
+        project = vimrtags.Project.get("/path/to/file.ext")
+
+        run_rc_command.assert_called_once_with(['--project', "/path/to/file.ext"])
+        self.assertIsNone(project)
+
+    def test_no_project_root(self, run_rc_command):
+        run_rc_command.return_value = "No matches found"
+
+        project = vimrtags.Project.get("/path/to/file.ext")
+
+        run_rc_command.assert_called_once_with(['--project', "/path/to/file.ext"])
+        self.assertIsNone(project)
+
+    @patch("plugin.vimrtags.Project._cache", None)
+    @patch("plugin.vimrtags.Project._rtags_data_dir", "/data/dir")
+    def test_known_data_dir_known_project(self, run_rc_command):
+        run_rc_command.return_value = "  /project/root "
+        cached_project = Mock()
+        vimrtags.Project._cache = {"/other/project": Mock(), "/project/root": cached_project}
+
+        project = vimrtags.Project.get("/path/to/file.ext")
+
+        run_rc_command.assert_called_once_with(['--project', "/path/to/file.ext"])
+        self.assertIs(project, cached_project)
+
+    @patch("plugin.vimrtags.Project._cache", None)
+    @patch("plugin.vimrtags.Project._rtags_data_dir", None)
+    def test_unknown_data_dir_known_project(self, run_rc_command):
+        run_rc_command.side_effect = [
+            "  /project/root ",
+            """
+some junk
+dataDir: /rtags/data
+other junk
+"""
+        ]
+        cached_project = Mock()
+        vimrtags.Project._cache = {"/other/project": Mock(), "/project/root": cached_project}
+
+        project = vimrtags.Project.get("/path/to/file.ext")
+
+        self.assertListEqual(
+            run_rc_command.call_args_list, [
+                call(['--project', "/path/to/file.ext"]),
+                call(['--status', 'info'])
+            ]
+        )
+        self.assertIs(project, cached_project)
+        self.assertEqual(vimrtags.Project._rtags_data_dir, "/rtags/data")
+
+    @patch("plugin.vimrtags.Project._cache", None)
+    @patch("plugin.vimrtags.Project._rtags_data_dir", "/data/dir")
+    def test_known_data_dir_unknown_project(self, run_rc_command):
+        run_rc_command.return_value = "  /project/root "
+        other_project = Mock()
+        vimrtags.Project._cache = {"/other/project": other_project}
+
+        project = vimrtags.Project.get("/path/to/file.ext")
+
+        run_rc_command.assert_called_once_with(['--project', "/path/to/file.ext"])
+        self.assertIsInstance(project, vimrtags.Project)
+        self.assertEqual(project._project_root, "/project/root")
+        self.assertDictEqual(
+            vimrtags.Project._cache, {
+                "/other/project": other_project, "/project/root": project
+            }
+        )
+
+
+@patch("plugin.vimrtags.logger", Mock(spec=logging.Logger))
+@patch("plugin.vimrtags.Project._rtags_data_dir", "/data/dir")
+class Test_Project_init(VimRtagsTest):
+    def test(self):
+        project = vimrtags.Project("/project/root/")
+
+        self.assertEqual(project._project_root, "/project/root/")
+        self.assertEqual(project._db_path, "/data/dir/_project_root_/project")
+
+
+@patch("plugin.vimrtags.logger", Mock(spec=logging.Logger))
+@patch("plugin.vimrtags.Project._rtags_data_dir", "/data/dir")
+@patch("plugin.vimrtags.os.path.getmtime", autospec=True)
+class Test_Project_last_updated_time(VimRtagsTest):
+    def test(self, getmtime):
+        project = vimrtags.Project("/file/path/")
+
+        mtime = project.last_updated_time()
+
+        getmtime.assert_called_once_with("/data/dir/_file_path_/project")
+        self.assertIs(mtime, getmtime.return_value)
+
+
+class Test_Diagnostic_from_rtags_errors(VimRtagsTest):
+    def test(self):
+        errors = [
+            {'type': "type 1", 'line': 123, 'column': 345, 'message': "a Issue: message 1"},
+            {'type': "skipped"},
+            {'type': "type 2", 'line': 567, 'column': 789, 'message': "a Issue: message 2"}
+        ]
+
+        diagnostics = vimrtags.Diagnostic.from_rtags_errors("/some/file.ext", errors)
+
+        self.assertEqual(len(diagnostics), 2)
+        self.assertEqual(diagnostics[0]._filename, "/some/file.ext")
+        self.assertEqual(diagnostics[0].line_num, 123)
+        self.assertEqual(diagnostics[0]._char_num, 345)
+        self.assertEqual(diagnostics[0].type, "type 1")
+        self.assertEqual(diagnostics[0].text, "message 1")
+        self.assertEqual(diagnostics[1]._filename, "/some/file.ext")
+        self.assertEqual(diagnostics[1].line_num, 567)
+        self.assertEqual(diagnostics[1]._char_num, 789)
+        self.assertEqual(diagnostics[1].type, "type 2")
+        self.assertEqual(diagnostics[1].text, "message 2")
+
+
+@patch("plugin.vimrtags.get_rtags_variable", autospec=True)
+@patch("plugin.vimrtags.Diagnostic._to_qlist_dict", autospec=True)
+class Test_Diagnostic_to_qlist_errors(VimRtagsTest):
+    def prepare(self, _to_qlist_dict):
+        self.diagnostics = [
+            vimrtags.Diagnostic("file2", 3, 1, "W", "message"),
+            vimrtags.Diagnostic("file2", 4, 2, "E", "message"),
+            vimrtags.Diagnostic("file2", 4, 3, "W", "message"),
+            vimrtags.Diagnostic("file1", 4, 4, "W", "message")
+        ]
+        # Unused char_num property used to record original ordering.
+        _to_qlist_dict.side_effect = lambda d: {"order": d._char_num}
+
+    def test_within_max_height(self, _to_qlist_dict, get_rtags_variable):
+        self.prepare(_to_qlist_dict)
+        get_rtags_variable.return_value = "10"
+
+        height, qlist = vimrtags.Diagnostic.to_qlist_errors(self.diagnostics)
+
+        self.assertEqual(height, 4)
+        self.assert_diagnostics(qlist)
+
+    def test_outside_max_height(self, _to_qlist_dict, get_rtags_variable):
+        self.prepare(_to_qlist_dict)
+        get_rtags_variable.return_value = "2"
+
+        height, qlist = vimrtags.Diagnostic.to_qlist_errors(self.diagnostics)
+
+        self.assertEqual(height, 2)
+        self.assert_diagnostics(qlist)
+
+    def assert_diagnostics(self, qlist):
+        self.assertListEqual(
+            json.loads(qlist), [
+                {"order": 2, "nr": 1},
+                {"order": 4, "nr": 2},
+                {"order": 1, "nr": 3},
+                {"order": 3, "nr": 4}
+            ]
+        )
+
+
+class Test_Diagnostic__to_qlist_dict(VimRtagsTest):
+    def test_warning(self):
+        diagnostic = vimrtags.Diagnostic("file", 3, 4, "warning", "mock text")
+
+        self.assertDictEqual(
+            diagnostic._to_qlist_dict(), {
+                'lnum': 3, 'col': 4, 'text': "mock text", 'filename': "file", 'type': "W"
+            }
+        )
+
+    def test_error(self):
+        diagnostic = vimrtags.Diagnostic("file", 3, 4, "error", "mock text")
+
+        self.assertDictEqual(
+            diagnostic._to_qlist_dict(), {
+                'lnum': 3, 'col': 4, 'text': "mock text", 'filename': "file", 'type': "E"
+            }
+        )
+
+    def test_fixit(self):
+        diagnostic = vimrtags.Diagnostic("file", 3, 4, "fixit", "mock text")
+
+        self.assertDictEqual(
+            diagnostic._to_qlist_dict(), {
+                'lnum': 3, 'col': 4, 'text': "mock text [FIXIT]", 'filename': "file", 'type': "E"
+            }
+        )
+
+
+@patch("plugin.vimrtags.logger", Mock(spec=logging.Logger))
+@patch("plugin.vimrtags.Sign._is_signs_defined", False)
+@patch("plugin.vimrtags.get_command_output", autospec=True)
+class Test_Sign__define_signs(VimRtagsTest):
+
+    def test_no_bg_colours(self, get_command_output):
+        get_command_output.return_value = (
+            "MockGroup         xxx term=underline ctermfg=236 guifg=#3F3F3F"
+        )
+
+        vimrtags.Sign._define_signs()
+
+        get_command_output.assert_called_once_with("highlight SignColumn")
+        self.assertEqual(vimrtags.Sign._is_signs_defined, True)
+        self.assert_signs("")
+
+    def test_no_link(self, get_command_output):
+        get_command_output.return_value = (
+            "MockGroup         "
+            "xxx term=underline ctermfg=236 ctermbg=233 guifg=#3F3F3F guibg=#121212"
+        )
+
+        vimrtags.Sign._define_signs()
+
+        get_command_output.assert_called_once_with("highlight SignColumn")
+        self.assertEqual(vimrtags.Sign._is_signs_defined, True)
+        self.assert_signs(" guibg=#121212 ctermbg=233")
+
+    def test_with_link(self, get_command_output):
+        get_command_output.side_effect = [
+            "MockGroup     xxx ctermfg=141 guifg=#BF81FA guibg=#1F1F1F"
+            "                   links to MockLink",
+            "MockLink         "
+            "xxx term=underline ctermfg=236 ctermbg=233 guifg=#3F3F3F guibg=#121212"
+        ]
+
+        vimrtags.Sign._define_signs()
+
+        self.assertListEqual(
+            get_command_output.call_args_list, [
+                call("highlight SignColumn"), call("highlight MockLink")
+            ]
+        )
+        self.assertEqual(vimrtags.Sign._is_signs_defined, True)
+        self.assert_signs(" guibg=#121212 ctermbg=233")
+
+    def assert_signs(self, bg):
+        vim.command.assert_has_calls([
+            call("highlight rtags_fixit guifg=#ff00ff ctermfg=5 %s" % bg),
+            call("highlight rtags_warning guifg=#fff000 ctermfg=11 %s" % bg),
+            call("highlight rtags_error guifg=#ff0000 ctermfg=1 %s" % bg),
+            call("sign define rtags_fixit text=Fx texthl=rtags_fixit"),
+            call("sign define rtags_warning text=W texthl=rtags_warning"),
+            call("sign define rtags_error text=E texthl=rtags_error")
+        ])
+
+
+@patch("plugin.vimrtags.get_command_output", autospec=True)
+class Test_Sign_used_ids(VimRtagsTest):
+    def test(self, get_command_output):
+        get_command_output.return_value = ("""
+--- Signs ---
+Signs for path/to/file.ext:
+    line=363  id=3000  name=MockSign
+    line=439  id=3001  name=MockSign
+    line=664  id=3005  name=MockSign
+    line=665  id=3006  name=MockSign
+""")
+
+        used_ids = vimrtags.Sign.used_ids(4)
+
+        self.assertSetEqual(used_ids, set([3000, 3001, 3005, 3006]))
+
+
+@patch("plugin.vimrtags.Sign._is_signs_defined", None)
+@patch("plugin.vimrtags.Sign._define_signs")
+class Test_Sign_init(VimRtagsTest):
+    def test_signs_already_defined(self, _define_signs):
+        vimrtags.Sign._is_signs_defined = True
+
+        sign = vimrtags.Sign(123, 234, "mock", 456)
+
+        self.assertFalse(_define_signs.called)
+        vim.command.assert_called_once_with('sign place 123 line=234 name=rtags_mock buffer=456')
+        self.assertEqual(sign.id, 123)
+        self.assertEqual(sign._vimbuffer_num, 456)
+
+    def test_signs_not_defined(self, _define_signs):
+        vimrtags.Sign._is_signs_defined = False
+
+        sign = vimrtags.Sign(123, 234, "mock", 456)
+
+        _define_signs.assert_called_once_with()
+        vim.command.assert_called_once_with('sign place 123 line=234 name=rtags_mock buffer=456')
+        self.assertEqual(sign.id, 123)
+        self.assertEqual(sign._vimbuffer_num, 456)
+
+
+@patch("plugin.vimrtags.Sign._is_signs_defined", True)
+class Test_Sign_unplace(VimRtagsTest):
+    def test(self):
+        sign = vimrtags.Sign(123, 456, "mock", 567)
+        vim.command.reset_mock()
+
+        sign.unplace()
+
+        vim.command.assert_called_once_with('sign unplace 123 buffer=567')
+
+
+class Test_get_command_output(VimRtagsTest):
+    def test(self):
+        output = vimrtags.get_command_output("some command")
+
+        vim.eval.assert_called_once_with('rtags#getCommandOutput("some command")')
+        self.assertIs(output, vim.eval.return_value)

--- a/tests/test_vimrtags.py
+++ b/tests/test_vimrtags.py
@@ -1,15 +1,18 @@
 import json
 import logging
 import sys
-from unittest import TestCase
-from unittest.mock import Mock, MagicMock, patch, call
+try:
+    from unittest import TestCase
+    from unittest.mock import Mock, MagicMock, patch, call
+except ImportError:
+    from unittest2 import TestCase
+    from mock import Mock, MagicMock, patch, call
 
-from nose.tools import set_trace
+#from nose.tools import set_trace
 
 # Create a mocked vim in the environment.
 vim = MagicMock()
 sys.modules["vim"] = vim
-
 with patch.object(logging, "FileHandler"):
     from plugin import vimrtags
 
@@ -244,14 +247,14 @@ class Test_Buffer_show_all_diagnostics(VimRtagsTest):
     def test_rc_fails(self, error, run_rc_command):
         run_rc_command.return_value = None
         vimrtags.Buffer.show_all_diagnostics()
-        error.assert_called()
+        self.assertTrue(error.called)
         self.assertFalse(vim.command.called)
 
     @patch("plugin.vimrtags.message", autospec=True)
     def test_no_diagnostics(self, message, run_rc_command):
         run_rc_command.return_value = '{"checkStyle": {}}'
         vimrtags.Buffer.show_all_diagnostics()
-        message.assert_called()
+        self.assertTrue(message.called)
         self.assertFalse(vim.command.called)
 
     def prepare(self, get_rtags_variable, Diagnostic, run_rc_command):
@@ -922,10 +925,10 @@ class Test_Buffer__update_loclist(BufferInstanceTest):
 class Test_Buffer__place_signs(BufferInstanceTest):
 
     def test(self, _place_sign, _reset_signs, Sign):
-        self.buffer._diagnostics = {
-            3: Mock(spec=vimrtags.Diagnostic, line_num=4, type="a"),
-            56: Mock(spec=vimrtags.Diagnostic, line_num=65, type="b")
-        }
+        self.buffer._diagnostics = MagicMock(values=Mock(return_value=[
+            Mock(spec=vimrtags.Diagnostic, line_num=4, type="a"),
+            Mock(spec=vimrtags.Diagnostic, line_num=65, type="b")
+        ]))
         calls = MagicMock()
         calls.attach_mock(_reset_signs, "reset")
         calls.attach_mock(_place_sign, "place")

--- a/tests/test_vimrtags.py
+++ b/tests/test_vimrtags.py
@@ -92,30 +92,30 @@ class Test_parse_completion_result(VimRtagsTest):
 
     def _with_parent_sig(self, kind):
         return {
-            'menu': "mock completion -- mock parent -- mock signature -- mock comment",
+            'menu': "mock parent -- mock signature -- mock comment",
             'word': "mock completion", 'kind': kind
         }
 
     def _with_sig(self, kind):
         return {
-            'menu': "mock completion -- mock signature -- mock comment", 'word': "mock completion",
+            'menu': "mock signature -- mock comment", 'word': "mock completion",
             'kind': kind
         }
 
     def _with_parent(self, kind):
         return {
-            'menu': "mock completion -- mock parent -- mock comment", 'word': "mock completion",
+            'menu': "mock parent -- mock comment", 'word': "mock completion",
             'kind': kind
         }
 
     def _with_comment(self, kind):
         return {
-            'menu': "mock completion -- mock comment", 'word': "mock completion", 'kind': kind
+            'menu': "mock comment", 'word': "mock completion", 'kind': kind
         }
 
     def _simple(self, kind):
         return {
-            'menu': "mock completion", 'word': "mock completion", 'kind': kind
+            'menu': "", 'word': "mock completion", 'kind': kind
         }
 
 


### PR DESCRIPTION
# Background
vim-rtags is the only vim plugin I could find that has the killer "rename symbol" feature for C++, as well as other great features, e.g. class hierarchy.  However, diagnostics and completions were nowhere near as friendly as [YouCompleteMe](https://github.com/Valloric/YouCompleteMe) and [ALE](https://github.com/w0rp/ale).  

Because of the aforementioned two plugins, I already had two clang builds of my project(s) going on at any one time, and with vim-rtags that made three, which is just plain wasteful.  vim-rtags was close to replacing all three with a single solution, so I set about adding some tweaks here and there. It's culminated in quite a refactor, especially for the python code (which I am much more familiar with than vimscript).

# Highlights
* Diagnostics are now shown automatically in the sign gutter, with improved rendering, and with the diagnostic message showing in the message window when the cursor is over that line. It uses simple polling to update diagnostics by default, with care taken to do as little work as possible.
* Fixits are now supported.  All fixits available for the current buffer are applied at once via `<leader>rx`.  Errors with fixits available are marked in the sign column by `Fx` and suffixed in the diagnostics lists by `[FIXIT]`.
* Completions include more information (signature, Doxygen docs) and set the `omnifunc` by default.  This allows for trivial compatibility with YouCompleteMe by simply disabling their built-in cpp completion.
* Added support for `--diagnostics-all` via `<leader>rD`, to show all errors for the entire project.

# Fixes
* Remove `shell=True` for python 3.5+ subprocess, since `shell=True` means arguments are passed to the *shell* process, rather than RTags.
* Use lists for commands ultimately sent to `subprocess` rather than `split`ing a string, which is better for e.g. filenames with spaces.

# Tweaks
* Sort diagnostics in the location list/quickfix list with errors at the top.
* Added extra error messages in a few places so it's clearer if e.g. vim-rtags is having problems communicating with rc / rdm.
* Logging is improved, including logging rdm output (if started by vim-rtags).  Everything is logged to `tempname`s by default.

# Misc
* I've added appropriate toggles for most of the new features, i.e. `g:rtagsAutoDiagnostics`, `g:rtagsDiagnosticsPollingInterval`, `g:rtagsCppOmnifunc`, `g:rtagsRdmLog`.
* Unit tests for the python code are included.
* Vim documentation and README updated (a bit).
* See the commit messages for more info.  I've tried to keep them reasonable, but there is one rather large commit (70f126b) where most of the python refactor takes place, sorry about that.
* I'm sure there's some controversial changes, and probably edge cases and other things that I've missed. I'm happy to work with you to make any changes.